### PR TITLE
NDT - Bugs fixes

### DIFF
--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/packages/subnet-merger/constants/subnet-merger.constants.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/packages/subnet-merger/constants/subnet-merger.constants.ts
@@ -19,7 +19,8 @@ export class SubnetMergerConstants {
     "file_type": "file_type" as "file_type",
     "file_status": "file_status" as "file_status",
     "sha_1": "sha-1" as "sha-1",
-    "last_deployed_file": "last_deployed_file" as "last_deployed_file"
+    "last_deployed_file": "last_deployed_file" as "last_deployed_file",
+    "file_capabilities": "file_capabilities" as "file_capabilities",
   }
 
   public static validateAPIKeys = {
@@ -41,7 +42,9 @@ export class SubnetMergerConstants {
     deployNDTFile: `${SubnetMergerConstants.baseApiUrl}/merger_deploy_ndt_config`,
     validationReports: `${SubnetMergerConstants.baseApiUrl}/merger_verify_ndt_reports`,
     updateBoundaryPortsState: `${SubnetMergerConstants.baseApiUrl}/merger_update_topoconfig`,
-    lastDeployedNDT: `${SubnetMergerConstants.baseApiUrl}/merger_deployed_ndt`
+    lastDeployedNDT: `${SubnetMergerConstants.baseApiUrl}/merger_deployed_ndt`,
+    mergerDeleteNdt: `${SubnetMergerConstants.baseApiUrl}/merger_delete_ndt`,
+    updateDeployNdtConfig: `${SubnetMergerConstants.baseApiUrl}/merger_update_deploy_ndt_config`
 
   }
 

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/packages/subnet-merger/constants/subnet-merger.constants.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/packages/subnet-merger/constants/subnet-merger.constants.ts
@@ -48,4 +48,8 @@ export class SubnetMergerConstants {
 
   }
 
+  public static ufmConfigAPI = {
+    ufmConfig: `${NdtViewService.ufmRESTBase}/app/ufm_config`
+  }
+
 }

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/packages/subnet-merger/services/subnet-merger-backend.service.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/packages/subnet-merger/services/subnet-merger-backend.service.ts
@@ -70,4 +70,9 @@ export class SubnetMergerBackendService {
     }];
     return this.httpService.post(url, payload);
   }
+
+  public getUFMConf(): Observable<any> {
+    const url = `${SubnetMergerConstants.ufmConfigAPI.ufmConfig}`;
+    return this.httpService.get(url);
+  }
 }

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/packages/subnet-merger/services/subnet-merger-backend.service.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/packages/subnet-merger/services/subnet-merger-backend.service.ts
@@ -53,4 +53,21 @@ export class SubnetMergerBackendService {
     const url = SubnetMergerConstants.mergerAPIs.lastDeployedNDT;
     return this.httpService.get(url);
   }
+
+  public updatePortBoundariesAndDeploy(fileName: string, state = SubnetMergerConstants.boundariesStates.noDiscover): Observable<any> {
+    const url = `${SubnetMergerConstants.mergerAPIs.updateDeployNdtConfig}`
+    const payload = {
+      [SubnetMergerConstants.validateAPIKeys.NDTFileName]: fileName,
+      [SubnetMergerConstants.boundariesStates.boundaryPortState]: state
+    };
+    return this.httpService.post(url, payload);
+  }
+
+  public deleteNDTFile(fileName: string): Observable<any> {
+    const url = `${SubnetMergerConstants.mergerAPIs.mergerDeleteNdt}`;
+    const payload = [{
+      file_name: fileName
+    }];
+    return this.httpService.post(url, payload);
+  }
 }

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/ndt-files-view/ndt-files-view.component.html
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/ndt-files-view/ndt-files-view.component.html
@@ -12,8 +12,13 @@
 </ng-template>
 
 <ng-template #initialMsgTmp>
-  There is no NDT file was uploaded before.Click
-  <a (click)="initialWizard.openWizard()">here</a> to upload the initial file
+  <ng-container *ngIf="subnetMergerIsEnabled; else disabledFeatureMsg">
+    There is no NDT file was uploaded before.Click
+    <a (click)="initialWizard.openWizard()">here</a> to upload the initial file
+  </ng-container>
+  <ng-template #disabledFeatureMsg>
+    The Subnet merger feature is disabled, please enable it via the UFM Configurations file and restart the UFM.
+  </ng-template>
 </ng-template>
 
 

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/ndt-files-view/ndt-files-view.component.html
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/ndt-files-view/ndt-files-view.component.html
@@ -21,28 +21,32 @@
                     (onDeployFinish)="onInitialDeployFinish($event)"></app-initial-wizard>
 
 <ng-template #fileNameTmp let-data>
-  {{data.col}}
   <ng-container *ngIf="data.col == activeNDTFile">
     <i class="fa active" tooltip="Active" placement="top" container="body"></i>
   </ng-container>
+  {{data.col}}
 </ng-template>
 
 <ng-template #actionsTmp let-data>
   <div
-    *ngIf="data.row.file != activeNDTFile"
     class="actions-btn-wrapper">
-    <i
+    <i *ngIf="data.row.file_capabilities[NDTFileCapabilities.Verify]"
       class="fa fa-tasks"
       [tooltip]="'Validate'"
       container="body"
       placement="left"
       (click)="onValidateClicked(data.row)">
     </i>
-    <i
-      *ngIf="data.row.file_status != NDTFileStatus.new"
+    <i *ngIf="data.row.file_capabilities[NDTFileCapabilities.Deploy]"
       class="fa fa-object-group" [tooltip]="'Deploy'" container="body"
       placement="right"
       (click)="onDeployClicked(data.row)">
+    </i>
+
+    <i *ngIf="data.row.file_capabilities[NDTFileCapabilities.Remove]"
+      class="fa fa-trash" [tooltip]="'Remove'" container="body"
+      placement="top"
+      (click)="onRemoveClicked(data.row)">
     </i>
   </div>
 </ng-template>

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/ndt-files-view/ndt-files-view.component.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/ndt-files-view/ndt-files-view.component.ts
@@ -28,12 +28,20 @@ export enum NDTFileStatus {
   deployed = "deployed"
 }
 
+export enum NDTFileCapabilities {
+  Verify = "Verify",
+  Deploy = "Deploy",
+  Update = "Update",
+  Remove = "Remove"
+}
+
 export interface INDTFile {
   [SubnetMergerConstants.NDTFileKeys.file]: string,
   [SubnetMergerConstants.NDTFileKeys.file_type]: string,
   [SubnetMergerConstants.NDTFileKeys.file_status]: NDTFileStatus,
   [SubnetMergerConstants.NDTFileKeys.timestamp]: string,
-  [SubnetMergerConstants.NDTFileKeys.sha_1]: string
+  [SubnetMergerConstants.NDTFileKeys.sha_1]: string,
+  [SubnetMergerConstants.NDTFileKeys.file_capabilities]: any,
 }
 
 @Component({
@@ -105,9 +113,23 @@ export class NdtFilesViewComponent implements OnInit, OnChanges {
             if (activeDeployedFile && activeDeployedFile[SubnetMergerConstants.NDTFileKeys.last_deployed_file]) {
               this.activeNDTFile = activeDeployedFile[SubnetMergerConstants.NDTFileKeys.last_deployed_file]
             }
+
+            this.ndtFiles = data.map((file) => {
+              const fileCapabilities = {};
+              file.file_capabilities.split(",").forEach((cap) => {
+                if (cap && cap.length) {
+                  fileCapabilities[cap] = cap;
+                }
+              });
+              if (file.file != this.activeNDTFile) {
+                fileCapabilities[NDTFileCapabilities.Remove] = NDTFileCapabilities.Remove;
+              }
+              file.file_capabilities = fileCapabilities;
+              return file;
+            }).slice();
+            this.cdr.detectChanges();
           }
         })
-        this.ndtFiles = data;
       }
     })
   }
@@ -145,18 +167,20 @@ export class NdtFilesViewComponent implements OnInit, OnChanges {
             [XCoreAgGridConstants.cellRendererParams]: {
               [XCoreAgGridConstants.ngTemplate]: this.actionsTmp
             },
-            [XCoreAgGridConstants.cellClass]: "center-aligned"
+            [XCoreAgGridConstants.cellClass]: "center-aligned",
+            [XCoreAgGridConstants.maxWidth]: 100
           },
         ]
       });
 
     Object.assign(this.tableOptions.extraOptions, {
-      [XCoreAgGridConstants.rightAdditionalControlsTemplate]: this.rightControlTemplates
+      [XCoreAgGridConstants.rightAdditionalControlsTemplate]: this.rightControlTemplates,
+      [XCoreAgGridConstants.suppressColumnsFiltering]: true
     })
   }
 
-  public get NDTFileStatus() {
-    return NDTFileStatus
+  public get NDTFileCapabilities() {
+    return NDTFileCapabilities
   }
 
   public onValidateClicked(row: INDTFile) {
@@ -175,8 +199,12 @@ export class NdtFilesViewComponent implements OnInit, OnChanges {
     })
   }
 
-  public fileIsDeployed(row: INDTFile) {
-    return row.file_status.includes(NDTFileStatus.deployed);
+  public onRemoveClicked(row: INDTFile) {
+    this.subnetMergerBackend.deleteNDTFile(row.file).subscribe({
+      next: (data) => {
+        this.subnetMergerViewService.refreshNDtsTable.emit();
+      }
+    })
   }
 
 }

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/new-merger-wizard/new-merger-wizard.component.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/new-merger-wizard/new-merger-wizard.component.ts
@@ -67,20 +67,13 @@ export class NewMergerWizardComponent implements OnInit {
 
   public onConnectClick(): void {
     this.deploying = true;
-    this.subnetMergerBackend.updatePortsBoundaries(this.activeDeployedFile).subscribe({
+    this.subnetMergerBackend.updatePortBoundariesAndDeploy(this.activeDeployedFile).subscribe({
       next: (data) => {
-        this.subnetMergerBackend.deployNDTFile(this.activeDeployedFile).subscribe({
-          next: (data) => {
-            this.deploying = false;
-            this.connected = true;
-            this.newMergerWizardService.tabs[1].isDisabled = false;
-            this.newMergerWizardService.tabs[0].isNextDisabled = false;
-            this.subnetMergerViewService.refreshNDtsTable.emit();
-          },
-          error: () => {
-            this.deploying = false;
-          }
-        })
+        this.deploying = false;
+        this.connected = true;
+        this.newMergerWizardService.tabs[1].isDisabled = false;
+        this.newMergerWizardService.tabs[0].isNextDisabled = false;
+        this.subnetMergerViewService.refreshNDtsTable.emit();
       },
       error: () => {
         this.deploying = false;
@@ -92,8 +85,8 @@ export class NewMergerWizardComponent implements OnInit {
     this.newUploadedFile = $event;
   }
 
-  public onReportCompleted($event:IonValidationCompletedEvent) {
-    if($event.isReportCompleted && $event.report.status != NDTStatusTypes.completedWithCriticalErrors) {
+  public onReportCompleted($event: IonValidationCompletedEvent) {
+    if ($event.isReportCompleted && $event.report.status != NDTStatusTypes.completedWithCriticalErrors) {
       this.newMergerWizardService.tabs[1].isNextDisabled = false;
     }
   }

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/validation-reports/validation-reports.component.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/validation-reports/validation-reports.component.ts
@@ -71,6 +71,10 @@ export class ValidationReportsComponent implements OnInit, OnDestroy {
         ]
       });
 
+    Object.assign(this.tableOptions.extraOptions, {
+      [XCoreAgGridConstants.suppressColumnsFiltering]: true
+    });
+
   }
 
   public loadData() {

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/validation-result/validation-result.component.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/components/validation-result/validation-result.component.ts
@@ -110,7 +110,8 @@ export class ValidationResultComponent implements OnInit, OnChanges, OnDestroy {
       })
 
     Object.assign(this.reportTableOptions.extraOptions, {
-      [XCoreAgGridConstants.leftAdditionalControlsTemplate]: this.leftControlTemplate
+      [XCoreAgGridConstants.leftAdditionalControlsTemplate]: this.leftControlTemplate,
+      [XCoreAgGridConstants.suppressColumnsFiltering]: true
     })
   }
 

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/subnet-merger-view.module.ts
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/src/app/ndt/views/subnet-merger-view/subnet-merger-view.module.ts
@@ -13,7 +13,6 @@ import {ValidationResultComponent} from './components/validation-result/validati
 import {XCoreAgGridModule} from "../../../../../sms-ui-suite/x-core-ag-grid/x-core-ag-grid.module";
 import {NdtFilesViewComponent} from './components/ndt-files-view/ndt-files-view.component';
 import {TooltipModule} from "ngx-bootstrap/tooltip";
-import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import { NewMergerWizardComponent } from './components/new-merger-wizard/new-merger-wizard.component';
 import { ValidationReportsComponent } from './components/validation-reports/validation-reports.component';
 
@@ -29,7 +28,6 @@ import { ValidationReportsComponent } from './components/validation-reports/vali
     ValidationReportsComponent
   ],
   imports: [
-    BrowserAnimationsModule,
     CommonModule,
     XWizardModule,
     FileUploaderModule,


### PR DESCRIPTION
- issue: 3439575: [NDT - Subnet Merger] The deploy & updating the ports boundary state should be in a one API
- issue: 3445887: [NDT - Subnet Merger] No remove NDT file to reinitiate the process
- issue: 3445794: [NDT - Subnet Merger] Fixing Restore Defaults of Displayed Columns is not working by hide it at all
- issue: 123456: [NDT - Subnet Merger] show/hide The file's actions based on file_capibilities