### PR TITLE
issue:3538330 Avoid writing to topoconfig file record for miswired links

### DIFF
--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/topo_diff/ndt_infra.py
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/topo_diff/ndt_infra.py
@@ -549,7 +549,7 @@ def create_topoconfig_file(links_info_dict, ndt_file_path, patterns,
                     error_message = "Failed to detect peer port GUID. Skip link in topoconfig file: peer device: {} peer port: {}".format(peer_device, peer_port)
                     logging.error(error_message)
                     file_creation_failed = True
-                    failed_lable_conversion.append(port_key.replace("___", " Port:"))
+                    failed_lable_conversion.append(link_key_peer.replace("___", " Port:"))
                     continue
                 # in case peer port is not a number - get number from mapping
                 if not peer_port.isnumeric():


### PR DESCRIPTION
In case and for peer in NDT file set incorrect port number in link between switches - the link defined as miswired and should not appear in topoconfig file with incorrect peer GUID, as it will fail opensm.