### PR TITLE
issue:3689453 Handle in NDT file creation and in topodiff error input

### DIFF
--- a/plugins/UFM_NDT_Plugin/ndt_file_creator.py
+++ b/plugins/UFM_NDT_Plugin/ndt_file_creator.py
@@ -177,10 +177,8 @@ def parse_ibdiagnet_dump(net_dump_file_path, include_down_ports=False,
                 # lines of switch
                 # split by "\"" to get destination device name
                 link_destination_host_info = line.split("\"")
-                if not link_destination_host_info:
-                    continue
                 link_info_list = link_destination_host_info[0].split(":")
-                if not link_info_list:
+                if not link_info_list or len(link_info_list) == 1:
                     # empty string or failed to split info using ":"
                     continue
                 link_state = link_info_list[2].strip().lower()

--- a/plugins/UFM_NDT_Plugin/ndt_file_creator.py
+++ b/plugins/UFM_NDT_Plugin/ndt_file_creator.py
@@ -57,14 +57,10 @@ def allocate_request_args(parser, release_version="1.0"):
     request.add_argument("-i", "--input_path", action="store",
                          required=None, default=None, choices=None,
                          help="Path to directory with ibdiagnet output. If not set - script will run ibdiagnet utility.")
-    request.add_argument("-d", "--include_down_ports", action="store",
-                         required=None, default="no",
-                         choices=["no", "yes"],
-                         help="Flag if to include in NDT file currently disconnected Switch ports. Default - no")
-    request.add_argument("-e", "--include_error_ports", action="store",
-                         required=None, default="no",
-                         choices=["no", "yes"],
-                         help="Flag if to include in NDT file Active Switch ports with link error. Default - no")
+    request.add_argument("-d", "--include_down_ports", default=False, action="store_true",
+                         help="Flag if to include in NDT file currently disconnected Switch ports")
+    request.add_argument("-e", "--include_error_ports", default=False, action="store_true",
+                         help="Flag if to include in NDT file Active Switch ports with link error")
 
     request.add_argument("-v", "--version", action="version", version = release_version)
 
@@ -248,8 +244,8 @@ def main():
     if not check_file_exist(ibdiag_net_dump_file):
         print("ibdiagnet output file %s not exist" % ibdiag_net_dump_file)
         exit(1)
-    include_down_ports = (request_arguments['include_down_ports'] == "yes")
-    include_error_ports = (request_arguments['include_error_ports'] == "yes")
+    include_down_ports = request_arguments['include_down_ports']
+    include_error_ports = request_arguments['include_error_ports']
     ibdiagnet_links, links_list_disconnected , links_list_errored = \
                                     parse_ibdiagnet_dump( ibdiag_net_dump_file,
                                                              include_down_ports,

--- a/plugins/UFM_NDT_Plugin/ufm_sim_web_service/merger_resources.py
+++ b/plugins/UFM_NDT_Plugin/ufm_sim_web_service/merger_resources.py
@@ -292,6 +292,9 @@ class MergerVerifyNDT(Compare):
         except ValueError as e:
             if "error" not in report_content:
                 report_content["error"] = e.args[0]
+        except Exception as e:
+            if "error" not in report_content:
+                report_content["error"] = "Unhandeled error %s" % e
         response, status_code = self.create_report(scope, report_content)
         if status_code != self.success:
             logging.error("Failed to create verification report: %s" % response)


### PR DESCRIPTION
from net_dump file
handle case when the port is Active but info about peer port not appear skip in ndt file creator lines with error peer information add ability in ndt creator to include as boundary, ports with error on peer recognition