### PR TITLE
issue:3819170:PDR deterministic plugin considers ports marked as 'Polling' status

### DIFF
--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -307,13 +307,11 @@ class IsolationMgr:
         if not self.temp_check:
             return None
         cable_temp = get_counter(Constants.TEMP_COUNTER, row, default=None)
-        self.logger.debug(f"Got cable temp {cable_temp} for port_obj {port_obj}")
         if cable_temp is not None and not numpy.isnan(cable_temp):
             if cable_temp in ["NA", "N/A", "", "0C"]:
                 return None
             cable_temp = int(cable_temp.split("C")[0]) if type(cable_temp) == str else cable_temp
             dT = abs(port_obj.counters_values.get(Constants.TEMP_COUNTER, 0) - cable_temp)
-            self.logger.debug(f"cable temp is {cable_temp}, dT is {dT},tmax is {self.tmax} and d_tmax is {self.d_tmax} so {cable_temp > self.tmax} or {dT > self.d_tmax}")
             port_obj.counters_values[Constants.TEMP_COUNTER] = cable_temp
             if cable_temp and (cable_temp > self.tmax or dT > self.d_tmax):
                 return Issue(port_obj.port_name, Constants.ISSUE_OONOC)
@@ -583,13 +581,12 @@ class IsolationMgr:
                 self.logger.info("Retrieving telemetry data to determine ports' states")
                 try:
                     issues = self.read_next_set_of_high_ber_or_pdr_ports(endpoint_port)
-                except DynamicTelemetryUnresponsive:
+                except DynamicTelemetryUnresponsive as e:
                     dynamic_telemetry_unresponsive_count += 1
-                    if dynamic_telemetry_unresponsive_count > self.dynamic_unresponsive_limit:
-                        self.logger.error(f"Dynamic telemetry is unresponsive for {dynamic_telemetry_unresponsive_count} times, restarting telemetry session...")
-                        endpoint_port = self.restart_telemetry_session()
-                        dynamic_telemetry_unresponsive_count = 0
-                    continue
+                if dynamic_telemetry_unresponsive_count > self.dynamic_unresponsive_limit:
+                    self.logger.error(f"Dynamic telemetry is unresponsive for {dynamic_telemetry_unresponsive_count} times, restarting telemetry session...")
+                    endpoint_port = self.restart_telemetry_session()
+                    dynamic_telemetry_unresponsive_count = 0
                 if len(issues) > self.max_num_isolate:
                     # UFM send external event
                     event_msg = "got too many ports detected as unhealthy: %d, skipping isolation" % len(issues)

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -307,11 +307,13 @@ class IsolationMgr:
         if not self.temp_check:
             return None
         cable_temp = get_counter(Constants.TEMP_COUNTER, row, default=None)
+        self.logger.debug(f"Got cable temp {cable_temp} for port_obj {port_obj}")
         if cable_temp is not None and not numpy.isnan(cable_temp):
             if cable_temp in ["NA", "N/A", "", "0C"]:
                 return None
             cable_temp = int(cable_temp.split("C")[0]) if type(cable_temp) == str else cable_temp
             dT = abs(port_obj.counters_values.get(Constants.TEMP_COUNTER, 0) - cable_temp)
+            self.logger.debug(f"cable temp is {cable_temp}, dT is {dT},tmax is {self.tmax} and d_tmax is {self.d_tmax} so {cable_temp > self.tmax} or {dT > self.d_tmax}")
             port_obj.counters_values[Constants.TEMP_COUNTER] = cable_temp
             if cable_temp and (cable_temp > self.tmax or dT > self.d_tmax):
                 return Issue(port_obj.port_name, Constants.ISSUE_OONOC)
@@ -579,12 +581,13 @@ class IsolationMgr:
                 self.logger.info("Retrieving telemetry data to determine ports' states")
                 try:
                     issues = self.read_next_set_of_high_ber_or_pdr_ports(endpoint_port)
-                except DynamicTelemetryUnresponsive as e:
+                except DynamicTelemetryUnresponsive:
                     dynamic_telemetry_unresponsive_count += 1
-                if dynamic_telemetry_unresponsive_count > self.dynamic_unresponsive_limit:
-                    self.logger.error(f"Dynamic telemetry is unresponsive for {dynamic_telemetry_unresponsive_count} times, restarting telemetry session...")
-                    endpoint_port = self.restart_telemetry_session()
-                    dynamic_telemetry_unresponsive_count = 0
+                    if dynamic_telemetry_unresponsive_count > self.dynamic_unresponsive_limit:
+                        self.logger.error(f"Dynamic telemetry is unresponsive for {dynamic_telemetry_unresponsive_count} times, restarting telemetry session...")
+                        endpoint_port = self.restart_telemetry_session()
+                        dynamic_telemetry_unresponsive_count = 0
+                    continue
                 if len(issues) > self.max_num_isolate:
                     # UFM send external event
                     event_msg = "got too many ports detected as unhealthy: %d, skipping isolation" % len(issues)

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -376,6 +376,8 @@ class IsolationMgr:
                     self.ports_data[port_name] = PortData(port_name=port_name,peer="0x"+port_name)
             port_obj = self.ports_data.get(port_name)
             if not port_obj:
+                if get_counter(Constants.RCV_PACKETS_COUNTER,row,0) == 0: # meaning it is down port
+                    continue
                 self.logger.warning("Port {0} not found in ports data".format(port_name))
                 continue
             # Converting from micro seconds to seconds.


### PR DESCRIPTION
## What
Add a check for the row before printing the warning, because disable port show at the telemetry..

## Why
[P2](https://redmine.mellanox.com/issues/3819170)