### PR TITLE
issue: 3865227: Fixing [UFM - TFS plugin] : Streaming into a Fluent server using the HTTP via IPv6 isn't working

### DIFF
--- a/plugins/fluentd_telemetry_plugin/src/streamer.py
+++ b/plugins/fluentd_telemetry_plugin/src/streamer.py
@@ -503,9 +503,11 @@ class UFMTelemetryStreaming(Singleton):
             }
 
             if self.compressed_streaming_flag:
+                _fluentd_host = self.fluentd_host
+                _fluentd_host = f'[{_fluentd_host}]' if Utils.is_ipv6_address(_fluentd_host) else _fluentd_host
                 compressed = gzip.compress(json.dumps(fluentd_message).encode('utf-8'))
                 res = requests.post(
-                    url=f'http://{self.fluentd_host}:{self.fluentd_port}/'
+                    url=f'http://{_fluentd_host}:{self.fluentd_port}/'
                         f'{UFMTelemetryConstants.PLUGIN_NAME}.{fluentd_msg_tag}',
                     data=compressed,
                     headers={"Content-Encoding": "gzip", "Content-Type": "application/json"})


### PR DESCRIPTION
## What ?
The streaming in the TFS isn't working using the HTTP protocol

## Why ?
Fixing [3865227](https://redmine.mellanox.com/issues/3865227)

## How ?
By adding the missing IPv6 brackets to the HTTP request URL
