### PR TITLE
issue: 3865233: Fixing [UFM - TFS plugin] : Streaming into a Fluent server using the C CLX Forward library with IPv6 isn't working

### DIFF
--- a/plugins/fluentd_telemetry_plugin/src/fluentbit_writer.py
+++ b/plugins/fluentd_telemetry_plugin/src/fluentbit_writer.py
@@ -80,19 +80,9 @@ class FluentBitCWriter(object):
         self.lib = None
         self.lib_path = None
 
-        default_plugin_host_port = 'forward:localhost:24224'
-        plugin_host_port = context.get('plugin_host_port', default_plugin_host_port)
-
-        plugin_host_port_parts = plugin_host_port.split(":")
-        if len(plugin_host_port_parts) != 3:
-            Logger.log_message("Failed to parse argument '%s'." % plugin_host_port, LOG_LEVELS.WARNING)
-            plugin_host_port = default_plugin_host_port
-            Logger.log_message("Fallback to default configuration '%s'" % plugin_host_port, LOG_LEVELS.WARNING)
-            plugin_host_port_parts = plugin_host_port.split(":")
-
-        self.plugin_name = plugin_host_port_parts[0]
-        self.host = plugin_host_port_parts[1]
-        self.port = plugin_host_port_parts[2]
+        self.plugin_name = context.get('plugin_name', 'forward')
+        self.host = context.get('plugin_host', 'localhost') # could be IPv4, IPv6 or Hostname
+        self.port = context.get('plugin_port', '24224')
 
         self.lib = context.get('so_lib')
         self.tag_prefix = context.get('tag_prefix', '')
@@ -181,9 +171,12 @@ def init_fb_writer(host, port, tag_prefix, timeout=120, use_c=True):
     if use_c:
         [lib, lib_path] = load_api_lib_from_path(LIB_RAW_MSGPACK_API_SO_PATH)
         ctx = {
-            'plugin_host_port': f'forward:{host}:{port}',
+            # 'plugin_host_port': f'forward:{host}:{port}',
             # 'plugin_host_port': 'stdout_raw:10.209.36.68:24226', # for testing
             # 'plugin_host_port': 'stdout:10.209.36.68:24226', # for testing
+            'plugin_name': 'forward',
+            'plugin_host': host,
+            'plugin_port': str(port),
             'msgpack_data_layout': 'standard',
             'so_lib': lib,
             'tag_prefix': tag_prefix
@@ -202,6 +195,8 @@ if __name__ == '__main__':
     # Example on how to set & use the FB writer
     _use_c = True
     _host = '10.209.36.67'
+    # _host = 'r-ufm254-hyp-03'
+    # _host = 'fcfc:fcfc:209:36:219:b9ff:fe0a:ed14'
     _port = '24224'
     _tag = 'UFM_Telemetry_Streaming'
     # record = Utils.read_json_from_file('../tests/message_samples/small_telemetry.json')

--- a/plugins/fluentd_telemetry_plugin/src/fluentbit_writer.py
+++ b/plugins/fluentd_telemetry_plugin/src/fluentbit_writer.py
@@ -172,8 +172,8 @@ def init_fb_writer(host, port, tag_prefix, timeout=120, use_c=True):
         [lib, lib_path] = load_api_lib_from_path(LIB_RAW_MSGPACK_API_SO_PATH)
         ctx = {
             # 'plugin_host_port': f'forward:{host}:{port}',
-            # 'plugin_host_port': 'stdout_raw:10.209.36.68:24226', # for testing
-            # 'plugin_host_port': 'stdout:10.209.36.68:24226', # for testing
+            # 'plugin_host_port': 'stdout_raw:127.0.0.1:24226', # for testing
+            # 'plugin_host_port': 'stdout:127.0.0.1:24226', # for testing
             'plugin_name': 'forward',
             'plugin_host': host,
             'plugin_port': str(port),
@@ -194,9 +194,9 @@ def init_fb_writer(host, port, tag_prefix, timeout=120, use_c=True):
 if __name__ == '__main__':
     # Example on how to set & use the FB writer
     _use_c = True
-    _host = '10.209.36.67'
-    # _host = 'r-ufm254-hyp-03'
-    # _host = 'fcfc:fcfc:209:36:219:b9ff:fe0a:ed14'
+    _host = '127.0.0.1'
+    # _host = 'localhost'
+    # _host = '0:0:0:0:0:0:0:0'
     _port = '24224'
     _tag = 'UFM_Telemetry_Streaming'
     # record = Utils.read_json_from_file('../tests/message_samples/small_telemetry.json')

--- a/plugins/fluentd_telemetry_plugin/src/fluentbit_writer.py
+++ b/plugins/fluentd_telemetry_plugin/src/fluentbit_writer.py
@@ -28,6 +28,9 @@ from utils.utils import Utils
 
 
 LIB_RAW_MSGPACK_API_SO_PATH = '/opt/ufm/telemetry/collectx/lib/libraw_msgpack_api.so'
+DEFAULT_FB_PLUGIN_NAME = 'forward'
+DEFAULT_FB_HOST = '127.0.0.1'
+DEFAULT_FB_PORT = '24224'
 
 
 def str2c_char_ptr(str_val):
@@ -80,9 +83,9 @@ class FluentBitCWriter(object):
         self.lib = None
         self.lib_path = None
 
-        self.plugin_name = context.get('plugin_name', 'forward')
-        self.host = context.get('plugin_host', 'localhost') # could be IPv4, IPv6 or Hostname
-        self.port = context.get('plugin_port', '24224')
+        self.plugin_name = context.get('plugin_name', DEFAULT_FB_PLUGIN_NAME)
+        self.host = context.get('plugin_host', DEFAULT_FB_HOST) # could be IPv4, IPv6 or Hostname
+        self.port = context.get('plugin_port', DEFAULT_FB_PORT)
 
         self.lib = context.get('so_lib')
         self.tag_prefix = context.get('tag_prefix', '')
@@ -171,9 +174,6 @@ def init_fb_writer(host, port, tag_prefix, timeout=120, use_c=True):
     if use_c:
         [lib, lib_path] = load_api_lib_from_path(LIB_RAW_MSGPACK_API_SO_PATH)
         ctx = {
-            # 'plugin_host_port': f'forward:{host}:{port}',
-            # 'plugin_host_port': 'stdout_raw:127.0.0.1:24226', # for testing
-            # 'plugin_host_port': 'stdout:127.0.0.1:24226', # for testing
             'plugin_name': 'forward',
             'plugin_host': host,
             'plugin_port': str(port),
@@ -194,12 +194,9 @@ def init_fb_writer(host, port, tag_prefix, timeout=120, use_c=True):
 if __name__ == '__main__':
     # Example on how to set & use the FB writer
     _use_c = True
-    _host = '127.0.0.1'
-    # _host = 'localhost'
-    # _host = '0:0:0:0:0:0:0:0'
-    _port = '24224'
+    _host = DEFAULT_FB_HOST
+    _port = DEFAULT_FB_PORT
     _tag = 'UFM_Telemetry_Streaming'
-    # record = Utils.read_json_from_file('../tests/message_samples/small_telemetry.json')
     msg_record = Utils.read_json_from_file('../tests/message_samples/small_telemetry.json')
     writer = init_fb_writer(_host, _port, _tag, use_c=_use_c)
     #####


### PR DESCRIPTION
## What ?
The streaming in the TFS isn't working using the Fluent C Forward protocol with IPv6

## Why ?
Fixing [3865233](https://redmine.mellanox.com/issues/3865233)

## How ?
splitting the plugin_host_port string by ":" won't work with IPv6, since IPv6 includes (:) as part of their standard notation, removing the unnecessary string manipulation will fix the issue