### PR TITLE
Fix for "Issue:3868454:Send a flag to disable the dynamic telemetry for the PDR"

### DIFF
--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -227,7 +227,6 @@ class IsolationMgr:
             "plugin_env_CLX_EXPORT_API_ENABLE_DOWN_PORT_COUNTERS": "1",
             "plugin_env_CLX_EXPORT_API_ENABLE_DOWN_PHY": "1",
             "arg_11": "",
-            "is_registered_discovery": False
         }
 
     def calc_max_ber_wait_time(self, min_threshold):

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -227,6 +227,7 @@ class IsolationMgr:
             "plugin_env_CLX_EXPORT_API_ENABLE_DOWN_PORT_COUNTERS": "1",
             "plugin_env_CLX_EXPORT_API_ENABLE_DOWN_PHY": "1",
             "arg_11": "",
+            "is_registered_discovery": "False"
         }
 
     def calc_max_ber_wait_time(self, min_threshold):


### PR DESCRIPTION
Reverts Mellanox/ufm_sdk_3.0#195