### PR TITLE
issue: 3621856: Fixing EFS plugin - High Vulnerability Severity

### DIFF
--- a/plugins/ufm_syslog_streaming_plugin/.ci/ci_matrix.yaml
+++ b/plugins/ufm_syslog_streaming_plugin/.ci/ci_matrix.yaml
@@ -1,5 +1,5 @@
 ---
-job: ufm-bright-plugin
+job: ufm-efs-plugin
 
 registry_host: harbor.mellanox.com
 registry_path: /swx-storage/ci-demo

--- a/plugins/ufm_syslog_streaming_plugin/.ci/ci_matrix.yaml
+++ b/plugins/ufm_syslog_streaming_plugin/.ci/ci_matrix.yaml
@@ -1,0 +1,54 @@
+---
+job: ufm-bright-plugin
+
+registry_host: harbor.mellanox.com
+registry_path: /swx-storage/ci-demo
+registry_auth: swx-storage
+
+env:
+  plugin_dir: efs_plugin
+  plugin_name: ufm-plugin-efs
+  DOCKER_CLI_EXPERIMENTAL: enabled
+
+kubernetes:
+  cloud: swx-k8s-spray
+
+volumes:
+  - {mountPath: /var/run/docker.sock, hostPath: /var/run/docker.sock}
+  - {mountPath: /auto/UFM, hostPath: /auto/UFM }
+
+
+runs_on_dockers:
+   - {file: '.ci/Dockerfile', arch: 'x86_64', name: 'plugin_worker', tag: 'latest'}
+
+
+steps:
+  - name: Build Plugin
+    containerSelector: "{name: 'plugin_worker'}"
+    run: |
+      cd plugins/$plugin_dir/build
+      bash -x ./docker_build.sh latest /
+      ls -l /
+      cp /ufm-plugin* /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/
+    parallel: true
+
+pipeline_start:
+  run: |
+    mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
+
+
+pipeline_stop:
+  run: |
+    echo 'All done';
+    #sudo rm -rf /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
+  
+
+
+
+
+
+
+
+
+# Fail job if one of the steps fails or continue
+failFast: false

--- a/plugins/ufm_syslog_streaming_plugin/.ci/ci_matrix.yaml
+++ b/plugins/ufm_syslog_streaming_plugin/.ci/ci_matrix.yaml
@@ -6,7 +6,7 @@ registry_path: /swx-storage/ci-demo
 registry_auth: swx-storage
 
 env:
-  plugin_dir: efs_plugin
+  plugin_dir: ufm_syslog_streaming_plugin
   plugin_name: ufm-plugin-efs
   DOCKER_CLI_EXPERIMENTAL: enabled
 

--- a/plugins/ufm_syslog_streaming_plugin/build/Dockerfile
+++ b/plugins/ufm_syslog_streaming_plugin/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS efs_base_ubuntu20
+FROM ubuntu:22.04 AS efs_base_ubuntu22
 
 LABEL maintainer="anana@nvidia.com"
 

--- a/plugins/ufm_syslog_streaming_plugin/build/Dockerfile
+++ b/plugins/ufm_syslog_streaming_plugin/build/Dockerfile
@@ -13,6 +13,9 @@ COPY ${SRC_BASE_DIR}/scripts/init.sh ${SRC_BASE_DIR}/scripts/deinit.sh /
 
 RUN apt-get update && apt-get -y install supervisor python3 python3-pip vim rsyslog curl sudo systemctl
 
+# remove an unused library that caused a high CVE vulnerability issue https://redmine.mellanox.com/issues/3621856
+RUN apt-get remove -y linux-libc-dev
+
 # install the fluent-bit
 RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 # add the symbolink


### PR DESCRIPTION
## What ?
The current EFS plugin didn't pass the ANCHORE-SCAN-DOCKER, it contains High Vulnerability Severity packages, such as the  linux-libc-dev

## Why ?
To fix [3621856](https://redmine.mellanox.com/issues/3621856) by removing/upgrading the problematic packages