### PR TITLE
issue:3621850: Fixing Bright plugin - High Vulnerability Severity

### DIFF
--- a/plugins/bright_plugin/build/Dockerfile
+++ b/plugins/bright_plugin/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS bright_plugin_base_ubuntu20
+FROM ubuntu:22.04 AS bright_plugin_base_ubuntu22
 
 LABEL maintainer="anana@nvidia.com"
 
@@ -12,9 +12,9 @@ COPY utils/ ${BASE_PATH}/utils/
 COPY ${SRC_BASE_DIR}/conf/supervisord.conf /etc/supervisor/conf.d/
 COPY ${SRC_BASE_DIR}/scripts/init.sh ${SRC_BASE_DIR}/scripts/deinit.sh /
 
-RUN apt-get update && apt-get -y install supervisor python3.9 python3-pip vim curl sudo
+RUN apt-get update && apt-get -y install supervisor python3 python3-pip vim curl sudo
 
-RUN python3.9 -m pip install -r ${BASE_PATH}/${SRC_BASE_DIR}/src/bright/requirements.txt
+RUN python3 -m pip install -r ${BASE_PATH}/${SRC_BASE_DIR}/src/bright/requirements.txt
 
 # remove an unused library that caused a high CVE vulnerability issue https://redmine.mellanox.com/issues/3621850
 RUN apt-get remove -y linux-libc-dev

--- a/plugins/bright_plugin/conf/supervisord.conf
+++ b/plugins/bright_plugin/conf/supervisord.conf
@@ -18,7 +18,7 @@ stderr_logfile_maxbytes=0
 
 [program:bright_plugin_service]
 directory=/opt/ufm/ufm_plugin_bright
-command=python3.9 /opt/ufm/ufm_plugin_bright/bright_plugin/src/bright/app.py
+command=python3 /opt/ufm/ufm_plugin_bright/bright_plugin/src/bright/app.py
 autostart=true
 autorestart=true
 startretries=1

--- a/plugins/bright_plugin/scripts/install_pythoncm.sh
+++ b/plugins/bright_plugin/scripts/install_pythoncm.sh
@@ -4,7 +4,7 @@ set -eE
 
 # install bright python API
 SRC_DIR_PATH=/opt/ufm/ufm_plugin_bright/bright_plugin
-PYTHON_PACKAGES_PATH=$(python3.9 -c 'import site; print(site.getsitepackages()[0])')
+PYTHON_PACKAGES_PATH=$(python3 -c 'import site; print(site.getsitepackages()[0])')
 mv $SRC_DIR_PATH/src/bright/pythoncm.tar.gz ${PYTHON_PACKAGES_PATH}
 tar -xf ${PYTHON_PACKAGES_PATH}/pythoncm.tar.gz -C ${PYTHON_PACKAGES_PATH}
 rm -rf ${PYTHON_PACKAGES_PATH}/pythoncm.tar.gz


### PR DESCRIPTION
## What ?
The current Bright plugin didn't pass the ANCHORE-SCAN-DOCKER, it contains High Vulnerability Severity packages, such as the  linux-libc-dev, python3.9

## Why ?
To fix [3621850](https://redmine.mellanox.com/issues/3621850) by removing/upgrading the problematic packages