### PR TITLE
issue: 3932766: [TFS Plugin]: Fixing The meta fields are broken when streaming.stream_only_new_samples flag is false

### DIFF
--- a/plugins/fluentd_telemetry_plugin/src/streamer.py
+++ b/plugins/fluentd_telemetry_plugin/src/streamer.py
@@ -513,8 +513,8 @@ class UFMTelemetryStreaming(Singleton):
                 key = modified_keys[i]
                 if value:
                     port_record[key] = self._convert_str_to_num(value)
-                    if is_meta_fields_available:
-                        port_record = self._append_meta_fields_to_dict(port_record)
+            if is_meta_fields_available:
+                port_record = self._append_meta_fields_to_dict(port_record)
             output.append(port_record)
         return output, None, keys_length
 


### PR DESCRIPTION
## What
The meta fields in the TFS are broken in the case of streaming.stream_only_new_samples is false

## Why ?
The root cause for this is appending the meta fields will occur before preparing the full port_record object, it's an indentation issue

