### PR TITLE
issue: 3943982: unifying the authentication service between the UFM host & UFM consumer plugin

### DIFF
--- a/plugins/ufm_consumer_plugin/conf/ufm_consumer_ui_conf.json
+++ b/plugins/ufm_consumer_plugin/conf/ufm_consumer_ui_conf.json
@@ -5,7 +5,7 @@
       "type": "leftMenu",
       "label": "UFM Consumer",
       "key": "ufm_consumer",
-      "route": ":APACHE_PORT",
+      "route": "/ufm_consumer_web",
       "icon": "fas fa-network-wired",
       "external": true
     }

--- a/plugins/ufm_consumer_plugin/conf/ufm_plugin_ufm_consumer_httpd.conf
+++ b/plugins/ufm_consumer_plugin/conf/ufm_plugin_ufm_consumer_httpd.conf
@@ -1,0 +1,24 @@
+Alias /ufm_consumer_web /opt/ufm/ufm_plugins_data/ufm_consumer/media
+
+<Directory "/opt/ufm/ufm_plugins_data/ufm_consumer/media">
+    Options Indexes MultiViews
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+    Header set X-Consumer-Plugin "yes"
+</Directory>
+
+<LocationMatch "^/ufmRestInternal/plugin/ufm_consumer/(?!run/)(.*)">
+    ProxyPassMatch http://127.0.0.1:@@CONSUMER_REST_PORT@@/$1 retry=1 Keepalive=On timeout=300
+    ProxyPassReverse http://127.0.0.1:@@CONSUMER_REST_PORT@@/$1
+    AuthType Basic
+    AuthName "UFM Consumer Plugin rest server"
+    WSGIPassAuthorization On
+    AuthBasicProvider wsgi
+    WSGIAuthUserScript /opt/ufm/scripts/ufm_authentication_scripts/auth.py
+    AuthBasicAuthoritative Off
+    ErrorDocument 401 /login
+    RequestHeader set X-Remote-User "%{REMOTE_USER}s"
+    RequestHeader unset X-Forwarded-Server
+    Require valid-user
+</LocationMatch>

--- a/plugins/ufm_consumer_plugin/scripts/config_consumer.sh
+++ b/plugins/ufm_consumer_plugin/scripts/config_consumer.sh
@@ -9,7 +9,8 @@ sqlite_conf=/config/sqlite
 sqlite_target=/opt/ufm/files/sqlite
 log_dir=/log
 auth_log_file_path=/opt/ufm/files/log/authentication_service.log
-
+ufm_media_original_path=/opt/ufm/media
+consumer_media_path=/data/media
 
 keep_config_file()
 {
@@ -118,5 +119,14 @@ fi
 
 chown -R ufmapp:ufmapp ${sqlite_target} ${sqlite_conf} ${log_dir}
 
-echo "Consumer configuration completed succesfully."
+# media directory of the UFM consumer should be shared with the host
+# it will be served by the Host's apache, it should be accessible via the host
+# /data default shared volume with the host's dir /opt/ufm/ufm_plugins_data/ufm_consumer/
+if [ ! -f ${consumer_media_path} ]; then
+    cp -r ${ufm_media_original_path} ${consumer_media_path}
+fi
+# update href base in the index.html of the UFM UI
+sed -i "s/ufm_web/ufm_consumer_web/g" ${consumer_media_path}/index.html
+
+echo "Consumer configuration completed successfully."
 exit 0

--- a/plugins/ufm_consumer_plugin/scripts/init.sh
+++ b/plugins/ufm_consumer_plugin/scripts/init.sh
@@ -34,7 +34,11 @@ update_http_apache_port() {
 
 echo /opt/ufm/files/licenses:/opt/ufm/files/licenses > /config/${PLUGIN_NAME}_shared_volumes.conf
 
-cp $SRC_DIR_PATH/conf/${PLUGIN_NAME}_httpd_proxy.conf $SRC_DIR_PATH/conf/${PLUGIN_NAME}_plugin.conf $SRC_DIR_PATH/conf/${PLUGIN_NAME}_ui_conf.json $SRC_DIR_PATH/conf/ufm_plugin_${PLUGIN_NAME}_httpd.conf ${CONFIG_PATH}
+cp $SRC_DIR_PATH/conf/${PLUGIN_NAME}_httpd_proxy.conf \
+   $SRC_DIR_PATH/conf/${PLUGIN_NAME}_plugin.conf \
+   $SRC_DIR_PATH/conf/${PLUGIN_NAME}_ui_conf.json \
+   $SRC_DIR_PATH/conf/ufm_plugin_${PLUGIN_NAME}_httpd.conf \
+   ${CONFIG_PATH}
 
 update_http_apache_port
 

--- a/plugins/ufm_consumer_plugin/scripts/init.sh
+++ b/plugins/ufm_consumer_plugin/scripts/init.sh
@@ -24,11 +24,7 @@ CONFIG_PATH=/config
 update_http_apache_port() {
   # update the plugin http port in the apache configurations
   port=8997 #default port
-  if [ -f ${CONFIG_PATH}/${PLUGIN_NAME}_httpd_proxy.conf ]; then
-    .  ${CONFIG_PATH}/${PLUGIN_NAME}_httpd_proxy.conf
-  else
-    echo "The file ${CONFIG_PATH}/${PLUGIN_NAME}_httpd_proxy.conf does not exist, setting the default port ${port}"
-  fi
+  .  ${CONFIG_PATH}/${PLUGIN_NAME}_httpd_proxy.conf
   sed -i "s/@@CONSUMER_REST_PORT@@/${port}/g" ${CONFIG_PATH}/ufm_plugin_${PLUGIN_NAME}_httpd.conf
 }
 

--- a/plugins/ufm_consumer_plugin/scripts/init.sh
+++ b/plugins/ufm_consumer_plugin/scripts/init.sh
@@ -21,9 +21,22 @@ PLUGIN_NAME=ufm_consumer
 SRC_DIR_PATH=/opt/ufm/ufm_plugin_${PLUGIN_NAME}/${PLUGIN_NAME}_plugin
 CONFIG_PATH=/config
 
+update_http_apache_port() {
+  # update the plugin http port in the apache configurations
+  port=8997 #default port
+  if [ -f ${CONFIG_PATH}/${PLUGIN_NAME}_httpd_proxy.conf ]; then
+    .  ${CONFIG_PATH}/${PLUGIN_NAME}_httpd_proxy.conf
+  else
+    echo "The file ${CONFIG_PATH}/${PLUGIN_NAME}_httpd_proxy.conf does not exist, setting the default port ${port}"
+  fi
+  sed -i "s/@@CONSUMER_REST_PORT@@/${port}/g" ${CONFIG_PATH}/ufm_plugin_${PLUGIN_NAME}_httpd.conf
+}
+
 echo /opt/ufm/files/licenses:/opt/ufm/files/licenses > /config/${PLUGIN_NAME}_shared_volumes.conf
 
-cp $SRC_DIR_PATH/conf/${PLUGIN_NAME}_httpd_proxy.conf $SRC_DIR_PATH/conf/${PLUGIN_NAME}_plugin.conf $SRC_DIR_PATH/conf/${PLUGIN_NAME}_ui_conf.json ${CONFIG_PATH}
+cp $SRC_DIR_PATH/conf/${PLUGIN_NAME}_httpd_proxy.conf $SRC_DIR_PATH/conf/${PLUGIN_NAME}_plugin.conf $SRC_DIR_PATH/conf/${PLUGIN_NAME}_ui_conf.json $SRC_DIR_PATH/conf/ufm_plugin_${PLUGIN_NAME}_httpd.conf ${CONFIG_PATH}
+
+update_http_apache_port
 
 # UFM version test
 required_ufm_version=(6 14 0)


### PR DESCRIPTION
## What
This PR will mainly extend the UFM host's Apache configurations to forward the consumer plugin's requests to the consumer's server directly, instead of using the ModelMain UFM plugin proxy

## Why ?
To fix [UFM Server] Bug SW [#3943041](https://redmine.mellanox.com/issues/3943041): Consumer plugin - enabling any of authentication methods (e.g. client cert.) on the UFM provider host won't be applied on the UFM consumer plugin

## How ?
By adding a new Location to the Apache that does the proxy to the consumer plugin's server instead of the modelmain port
The new location is protected using the UFM host's authentication server.
with this change, both applications (main UFM host & Consumer UFM) are protected via one centralized authentication service 

**The new file [ufm_plugin_ufm_consumer_httpd.conf](https://github.com/Mellanox/ufm_sdk_3.0/pull/223/files#diff-4b80af4f1c8fe35fdb51634b81913c11712d717aca58b223363a10c8df0f310b) is added temporarily, the plan is to have this configurations shared and managed by the plugins manager for all plugins**

## Testing ?
Manual Testing, by adding the new consumer plugin image to the UFM, trying to access the UFM consumer GUI/ REST API using different authentication methods (e.g. basic/session + client cert., tokens)

**This fix will only work with the client cert. when the authentication service is enabled.**