### PR TITLE
issue:#4027497: Create a class that pulls the secondary telemetry every interval and send an event that new data is ready

### DIFF
--- a/plugins/pdr_deterministic_plugin/build/config/pdr_deterministic.conf
+++ b/plugins/pdr_deterministic_plugin/build/config/pdr_deterministic.conf
@@ -27,9 +27,6 @@ DEISOLATE_CONSIDER_TIME=300
 AUTOMATIC_DEISOLATE=True
 # if set to false, the plugin will not perform deisolation
 DO_DEISOLATION=True
-DYNAMIC_WAIT_TIME=30
-# number of times to check if a dynamic session is unresponsive before restarting it
-DYNAMIC_UNRESPONSIVE_LIMIT=3
 
 [Metrics]
 # in Celsius

--- a/plugins/pdr_deterministic_plugin/tests/simulation_telemetry.py
+++ b/plugins/pdr_deterministic_plugin/tests/simulation_telemetry.py
@@ -25,12 +25,12 @@ from utils.utils import Utils
 lock = Lock()
 
 PHY_EFF_ERROR = "phy_effective_errors"
-PHY_SYMBOL_ERROR = "phy_symbol_errors"
+PHY_SYMBOL_ERROR = "Symbol_Errors"
 RCV_PACKETS_COUNTER = "PortRcvPktsExtended"
-RCV_ERRORS_COUNTER = "PortRcvErrorsExtended"
-LINK_DOWN_COUNTER = "LinkDownedCounterExtended"
-RCV_REMOTE_PHY_ERROR_COUNTER = "PortRcvRemotePhysicalErrorsExtended"
-TEMP_COUNTER = "CableInfo.Temperature"
+RCV_ERRORS_COUNTER = "PortRcvErrors"
+LINK_DOWN_COUNTER = "Link_Down_IB"
+RCV_REMOTE_PHY_ERROR_COUNTER = "PortRcvRemotePhysicalErrors"
+TEMP_COUNTER = "Module_Temperature"
 FEC_MODE = "fec_mode_active"
 ENDPOINT_CONFIG = {}
 

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/constants.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/constants.py
@@ -43,6 +43,7 @@ class PDRConstants(object):
     SWITCH_TO_HOST_ISOLATION = "SWITCH_TO_HOST_ISOLATION"
     TEST_MODE = "TEST_MODE"
     TEST_MODE_PORT = 9090
+    SECONDARY_TELEMETRY_PORT = 9002
     DYNAMIC_UNRESPONSIVE_LIMIT = "DYNAMIC_UNRESPONSIVE_LIMIT"
 
     GET_SESSION_DATA_REST = "/monitoring/session/0/data"
@@ -55,6 +56,7 @@ class PDRConstants(object):
     API_ISOLATED_PORTS = "isolated_ports"
     DYNAMIC_SESSION_REST = "/app/telemetry/instances/%s"
     STATUS_DYNAMIC_SESSION_REST = "/app/telemetry/instances/status"
+    SECONDARY_INSTANCE = "low_freq_debug"
 
     EXTERNAL_EVENT_ERROR = 554
     EXTERNAL_EVENT_ALERT = 553
@@ -70,12 +72,12 @@ class PDRConstants(object):
     CONF_USERNAME = 'admin'
     CONF_PASSWORD = 'password'
 
-    TEMP_COUNTER = "CableInfo.Temperature"
-    ERRORS_COUNTER = "errors"
+    ERRORS_COUNTER = "Symbol_Errors"
     RCV_PACKETS_COUNTER = "PortRcvPktsExtended"
-    RCV_ERRORS_COUNTER = "PortRcvErrorsExtended"
-    RCV_REMOTE_PHY_ERROR_COUNTER = "PortRcvRemotePhysicalErrorsExtended"
-    LNK_DOWNED_COUNTER = "LinkDownedCounterExtended"
+    RCV_ERRORS_COUNTER = "PortRcvErrors"
+    RCV_REMOTE_PHY_ERROR_COUNTER = "PortRcvRemotePhysicalErrors"
+    TEMP_COUNTER = "Module_Temperature"
+    LNK_DOWNED_COUNTER = "Link_Down_IB"
 
     PHY_RAW_ERROR_LANE0 = "phy_raw_errors_lane0"
     PHY_RAW_ERROR_LANE1 = "phy_raw_errors_lane1"

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -456,13 +456,11 @@ class IsolationMgr:
         if not self.temp_check:
             return None
         cable_temp = get_counter(Constants.TEMP_COUNTER, row, default=None)
-        self.logger.debug(f"Got cable temp {cable_temp} for port_obj {port_obj}")
         if cable_temp is not None and not numpy.isnan(cable_temp):
             if cable_temp in ["NA", "N/A", "", "0C"]:
                 return None
             cable_temp = int(cable_temp.split("C")[0]) if type(cable_temp) == str else cable_temp
             dT = abs(port_obj.counters_values.get(Constants.TEMP_COUNTER, 0) - cable_temp)
-            self.logger.debug(f"cable temp is {cable_temp}, dT is {dT},tmax is {self.tmax} and d_tmax is {self.d_tmax} so {cable_temp > self.tmax} or {dT > self.d_tmax}")
             port_obj.counters_values[Constants.TEMP_COUNTER] = cable_temp
             # Check temperature condition
             if cable_temp and (cable_temp > self.tmax):

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -456,11 +456,13 @@ class IsolationMgr:
         if not self.temp_check:
             return None
         cable_temp = get_counter(Constants.TEMP_COUNTER, row, default=None)
+        self.logger.debug(f"Got cable temp {cable_temp} for port_obj {port_obj}")
         if cable_temp is not None and not numpy.isnan(cable_temp):
             if cable_temp in ["NA", "N/A", "", "0C"]:
                 return None
             cable_temp = int(cable_temp.split("C")[0]) if type(cable_temp) == str else cable_temp
             dT = abs(port_obj.counters_values.get(Constants.TEMP_COUNTER, 0) - cable_temp)
+            self.logger.debug(f"cable temp is {cable_temp}, dT is {dT},tmax is {self.tmax} and d_tmax is {self.d_tmax} so {cable_temp > self.tmax} or {dT > self.d_tmax}")
             port_obj.counters_values[Constants.TEMP_COUNTER] = cable_temp
             # Check temperature condition
             if cable_temp and (cable_temp > self.tmax):

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -156,7 +156,7 @@ def get_counter(counter_name, row, default=0):
      or its value is NaN.
     """
     try:
-        val = row.get(counter_name) if (row.get(counter_name) is not None and not pd.isna(row.get(counter_name))) else default
+        val = row.get(counter_name) if (row.get(counter_name) is not None and not numpy.isnan(row.get(counter_name))) else default
     except Exception as e:
         return default
     return val

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -22,16 +22,8 @@ import numpy
 from exclude_list import ExcludeList
 
 from constants import PDRConstants as Constants
-from ufm_communication_mgr import DynamicSessionState, UFMCommunicator
+from ufm_communication_mgr import UFMCommunicator
 # should actually be persistent and thread safe dictionary pf PortStates
-
-
-class DynamicTelemetryUnresponsive(Exception):
-    """
-    Exception raised when the dynamic telemetry is unresponsive.
-    """
-    pass
-
 
 class PortData(object):
     """
@@ -194,13 +186,11 @@ class IsolationMgr:
         self.do_deisolate = pdr_config.getboolean(Constants.CONF_ISOLATION,Constants.DO_DEISOLATION)
         self.deisolate_consider_time = pdr_config.getint(Constants.CONF_ISOLATION,Constants.DEISOLATE_CONSIDER_TIME)
         self.automatic_deisolate = pdr_config.getboolean(Constants.CONF_ISOLATION,Constants.AUTOMATIC_DEISOLATE)
-        self.dynamic_wait_time = pdr_config.getint(Constants.CONF_ISOLATION,"DYNAMIC_WAIT_TIME")
         self.temp_check = pdr_config.getboolean(Constants.CONF_ISOLATION,Constants.CONFIGURED_TEMP_CHECK)
         self.link_down_isolation = pdr_config.getboolean(Constants.CONF_ISOLATION,Constants.LINK_DOWN_ISOLATION)
         self.switch_hca_isolation = pdr_config.getboolean(Constants.CONF_ISOLATION,Constants.SWITCH_TO_HOST_ISOLATION)
         self.test_mode = pdr_config.getboolean(Constants.CONF_COMMON,Constants.TEST_MODE, fallback=False)
         self.test_iteration = 0
-        self.dynamic_unresponsive_limit = pdr_config.getint(Constants.CONF_ISOLATION,Constants.DYNAMIC_UNRESPONSIVE_LIMIT, fallback=3)
         # Take from Conf
         self.logger = logger
         self.ber_intervals = Constants.BER_THRESHOLDS_INTERVALS if not self.test_mode else [[0.5 * 60, 3]]
@@ -540,17 +530,16 @@ class IsolationMgr:
                     return Issue(port_obj.port_name, Constants.ISSUE_BER)
         return None
 
-    def read_next_set_of_high_ber_or_pdr_ports(self, endpoint_port):
+    def read_next_set_of_high_ber_or_pdr_ports(self):
         """
         Read the next set of ports and check if they have high BER, PDR, temperature or link downed issues
         """
         issues = {}
-        ports_counters = self.ufm_client.get_telemetry(endpoint_port, Constants.PDR_DYNAMIC_NAME,self.test_mode)
+        ports_counters = self.ufm_client.get_telemetry(Constants.SECONDARY_TELEMETRY_PORT, Constants.SECONDARY_INSTANCE, self.test_mode)
         if ports_counters is None:
             self.logger.error("Couldn't retrieve telemetry data")
-            raise DynamicTelemetryUnresponsive
-        for index, row in ports_counters.iterrows():
-            port_name = f"{row.get('port_guid', '').split('x')[-1]}_{row.get('port_num', '')}"
+        for _, row in ports_counters.iterrows():
+            port_name = f"{row.get('Node_GUID', '').split('x')[-1]}_{row.get('Port_Number', '')}"
             if self.exclude_list.contains(port_name):
                 # The port is excluded from analysis
                 continue
@@ -764,35 +753,6 @@ class IsolationMgr:
                 port_state.update(Constants.STATE_ISOLATED, Constants.ISSUE_OONOC)
                 self.ports_states[port] = port_state
 
-    def start_telemetry_session(self):
-        """
-        Starts a telemetry session.
-
-        Returns:
-            str: The port number if the dynamic session is started successfully, False otherwise.
-        """
-        self.logger.info("Starting telemetry session")
-        guids = self.get_requested_guids()
-        response = self.ufm_client.start_dynamic_session(Constants.PDR_DYNAMIC_NAME, self.telemetry_counters, self.interval, guids, self.dynamic_extra_configuration)
-        if response and response.status_code == http.HTTPStatus.ACCEPTED:
-            port = str(int(response.content))
-        else:
-            self.logger.error(f"Failed to start dynamic session: {response}")
-            return False
-        return port
-
-    def update_telemetry_session(self):
-        """
-        Updates the telemetry session by requesting and updating the dynamic session with the specified interval and guids.
-
-        Returns:
-            The response from the UFM client after updating the dynamic session.
-        """
-        self.logger.info("Updating telemetry session")
-        guids = self.get_requested_guids()
-        response = self.ufm_client.update_dynamic_session(Constants.PDR_DYNAMIC_NAME, self.interval, guids)
-        return response
-
     def get_requested_guids(self):
         """
         Get the requested GUIDs and their corresponding ports.
@@ -809,55 +769,6 @@ class IsolationMgr:
                 guids[sys_guid] = [port.port_num]
         requested_guids = [{"guid": sys_guid, "ports": ports} for sys_guid, ports in guids.items()]
         return requested_guids
-
-    # this function create dynamic telemetry and returns the port of this telemetry
-    def run_telemetry_get_port(self):
-        """
-        Runs the telemetry and returns the endpoint port.
-
-        If the test mode is enabled, it returns the test mode port.
-        Otherwise, it waits for the dynamic session to start, starts the telemetry session,
-        and retrieves the endpoint port.
-
-        Returns:
-            int: The endpoint port for the telemetry.
-
-        Raises:
-            Exception: If an error occurs during the process.
-        """
-        if self.test_mode:
-            return Constants.TEST_MODE_PORT
-        try:
-            while True:
-                session_state = self.ufm_client.get_dynamic_session_state(Constants.PDR_DYNAMIC_NAME)
-                if session_state == DynamicSessionState.RUNNING:
-                    # Telemetry session is running
-                    break
-                if session_state == DynamicSessionState.NONE:
-                    # Start new session
-                    self.logger.info("Waiting for dynamic session to start")
-                    endpoint_port = self.start_telemetry_session()
-                    time.sleep(self.dynamic_wait_time)
-                else:
-                    # Stop inactive session
-                    self.logger.info("Waiting for inactive dynamic session to stop")
-                    self.ufm_client.stop_dynamic_session(Constants.PDR_DYNAMIC_NAME)
-                    time.sleep(self.dynamic_wait_time)
-        except Exception as e:
-            self.ufm_client.stop_dynamic_session(Constants.PDR_DYNAMIC_NAME)
-            time.sleep(self.dynamic_wait_time)
-        endpoint_port = self.ufm_client.dynamic_session_get_port(Constants.PDR_DYNAMIC_NAME)
-        return endpoint_port
-
-    def restart_telemetry_session(self):
-        """
-        Restart the dynamic telemetry session and return the new endpoint port
-        """
-        self.logger.info("Restarting telemetry session")
-        self.ufm_client.stop_dynamic_session(Constants.PDR_DYNAMIC_NAME)
-        time.sleep(self.dynamic_wait_time)
-        endpoint_port = self.run_telemetry_get_port()
-        return endpoint_port
 
     def main_flow(self):
         """
@@ -878,9 +789,6 @@ class IsolationMgr:
         self.logger.info("Isolation Manager initialized, starting isolation loop")
         self.get_ports_metadata()
         self.logger.info("Retrieved ports metadata")
-        endpoint_port = self.run_telemetry_get_port()
-        self.logger.info("telemetry session started")
-        dynamic_telemetry_unresponsive_count = 0
         while(True):
             try:
                 t_begin = time.time()
@@ -892,15 +800,9 @@ class IsolationMgr:
                     self.logger.info(f"Retrieving test mode telemetry data to determine ports' states: iteration {self.test_iteration}")
                     self.test_iteration += 1
                 try:
-                    issues = self.read_next_set_of_high_ber_or_pdr_ports(endpoint_port)
-                except DynamicTelemetryUnresponsive:
-                except DynamicTelemetryUnresponsive:
-                    dynamic_telemetry_unresponsive_count += 1
-                    if dynamic_telemetry_unresponsive_count > self.dynamic_unresponsive_limit:
-                        self.logger.error(f"Dynamic telemetry is unresponsive for {dynamic_telemetry_unresponsive_count} times, restarting telemetry session...")
-                        endpoint_port = self.restart_telemetry_session()
-                        dynamic_telemetry_unresponsive_count = 0
-                    continue
+                    issues = self.read_next_set_of_high_ber_or_pdr_ports()
+                except (KeyError,) as e:
+                    self.logger.error(f"failure to read information due to {e}")
                 if len(issues) > self.max_num_isolate:
                     # UFM send external event
                     event_msg = "got too many ports detected as unhealthy: %d, skipping isolation" % len(issues)
@@ -935,7 +837,3 @@ class IsolationMgr:
                 self.logger.warning(traceback_err)
                 t_end = time.time()      
             time.sleep(max(1, self.interval - (t_end - t_begin)))
-
-# this is a callback for API exposed by this code - second phase
-# def work_reportingd(port):
-#     PORTS_STATE[port].update(Constants.STATE_TREATED, Constants.ISSUE_INIT)


### PR DESCRIPTION
## What
replacing the dynamic telemetry session with secondary telemetry.
Removing all the parts connected to the dynamic telemetry session.
## Why ?
[Task](https://redmine.mellanox.com/issues/4027497)
first task in order to merge the ALM plugin and PDR plugin, we want to take secondary telemetry in the code.
## How ?
_It is optional, but for complex PRs please provide information about the design,
architecture, approach, etc._

## Testing ?
Changed the consts in the tests with the same constants to work as well.

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
