### PR TITLE
Issue:4044453:Replace the flask framework with aiohttp in PDR plugin

### DIFF
--- a/plugins/pdr_deterministic_plugin/README.md
+++ b/plugins/pdr_deterministic_plugin/README.md
@@ -90,7 +90,7 @@ The ports are added or removed to blacklist via PDR plugin Rest API.
 Add ports to exclude list (to be excluded from the analysis):
     curl -k -i -X PUT 'http://<host_ip>/excluded' -d '[<formatted_ports_list>]'
     TTL (time to live in blacklist) can optionally follow the port after the comma (if zero or not specified, then port is excluded forever)
-    Example: curl -k -i -X PUT 'http://127.0.0.1:8977/excluded' -d '[["9c0591030085ac80_45"],["9c0591030085ac80_46",300]' (first port is added forever, second - just for 300 seconds)
+    Example: curl -k -i -X PUT 'http://127.0.0.1:8977/excluded' -d '[["9c0591030085ac80_45"],["9c0591030085ac80_46",300]]' (first port is added forever, second - just for 300 seconds)
 
 Remove ports from exclude list
     curl -k -i -X DELETE 'http://<host_ip>/excluded' -d '[<comma_separated_port_mames>]'

--- a/plugins/pdr_deterministic_plugin/build/Dockerfile
+++ b/plugins/pdr_deterministic_plugin/build/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 9007
 
 RUN apt-get update && apt-get -y install supervisor python3 python3-pip rsyslog vim curl sudo
 
-RUN python3 -m pip install requests twisted jsonschema pandas numpy aiohttp
+RUN python3 -m pip install requests jsonschema pandas numpy aiohttp
 
 # remove an unused library that caused a high CVE vulnerability issue https://redmine.mellanox.com/issues/3837452
 RUN apt-get remove -y linux-libc-dev

--- a/plugins/pdr_deterministic_plugin/build/Dockerfile
+++ b/plugins/pdr_deterministic_plugin/build/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 9007
 
 RUN apt-get update && apt-get -y install supervisor python3 python3-pip rsyslog vim curl sudo
 
-RUN python3 -m pip install flask flask_restful requests twisted jsonschema pandas numpy
+RUN python3 -m pip install flask flask_restful requests twisted jsonschema pandas numpy aiohttp
 
 # remove an unused library that caused a high CVE vulnerability issue https://redmine.mellanox.com/issues/3837452
 RUN apt-get remove -y linux-libc-dev

--- a/plugins/pdr_deterministic_plugin/build/Dockerfile
+++ b/plugins/pdr_deterministic_plugin/build/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 9007
 
 RUN apt-get update && apt-get -y install supervisor python3 python3-pip rsyslog vim curl sudo
 
-RUN python3 -m pip install flask flask_restful requests twisted jsonschema pandas numpy aiohttp
+RUN python3 -m pip install requests twisted jsonschema pandas numpy aiohttp
 
 # remove an unused library that caused a high CVE vulnerability issue https://redmine.mellanox.com/issues/3837452
 RUN apt-get remove -y linux-libc-dev

--- a/plugins/pdr_deterministic_plugin/requirements.txt
+++ b/plugins/pdr_deterministic_plugin/requirements.txt
@@ -2,7 +2,6 @@ numpy<=1.26.4
 pandas<=2.2.2
 pytest<=8.2.0
 requests<=2.31.0
-twisted<=22.1.0
 tzlocal<=4.2
 jsonschema<=4.5.1
 aiohttp<=3.9.1

--- a/plugins/pdr_deterministic_plugin/requirements.txt
+++ b/plugins/pdr_deterministic_plugin/requirements.txt
@@ -1,10 +1,8 @@
-flask<=3.0.3
 numpy<=1.26.4
 pandas<=2.2.2
 pytest<=8.2.0
 requests<=2.31.0
 twisted<=22.1.0
-flask_restful<=0.3.10
 tzlocal<=4.2
 jsonschema<=4.5.1
 aiohttp<=3.9.1

--- a/plugins/pdr_deterministic_plugin/requirements.txt
+++ b/plugins/pdr_deterministic_plugin/requirements.txt
@@ -7,3 +7,4 @@ twisted<=22.1.0
 flask_restful<=0.3.10
 tzlocal<=4.2
 jsonschema<=4.5.1
+aiohttp<=3.9.1

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/base_aiohttp_api.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/base_aiohttp_api.py
@@ -36,11 +36,11 @@ class BaseAiohttpAPI:
         """
         self.app.router.add_route(method, path, handler)
 
-    def create_response(self, data):
+    def web_response(self, text, status):
         """
         Create response object.
         """
-        return web.json_response(data)
+        return web.json_response(text=text, status=status)
 
 
 class BaseAiohttpServer:

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/base_aiohttp_api.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/base_aiohttp_api.py
@@ -36,6 +36,12 @@ class BaseAiohttpAPI:
         """
         self.app.router.add_route(method, path, handler)
 
+    def create_response(self, data):
+        """
+        Create response object.
+        """
+        return web.json_response(data)
+
 
 class BaseAiohttpServer:
     """

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/base_aiohttp_api.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/base_aiohttp_api.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2013-2022 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright © 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # This software product is a proprietary product of Nvidia Corporation and its affiliates
 # (the "Company") and all right, title, and interest in and to the software

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/base_aiohttp_api.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/base_aiohttp_api.py
@@ -1,0 +1,75 @@
+#
+# Copyright © 2013-2022 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+import asyncio
+from aiohttp import web
+
+class BaseAiohttpAPI:
+    """
+    Base class for API implemented with aiohttp
+    """
+    def __init__(self):
+        """
+        Initialize a new instance of the BaseAiohttpAPI class.
+        """
+        self.app = web.Application()
+
+    @property
+    def application(self):
+        """
+        Read-only property for the application instance.
+        """
+        return self.app
+
+    def add_route(self, method, path, handler):
+        """
+        Add route to API.
+        """
+        self.app.router.add_route(method, path, handler)
+
+
+class BaseAiohttpServer:
+    """
+    Base class for HTTP server implemented with aiohttp
+    """
+    def __init__(self, logger):
+        """
+        Initialize a new instance of the BaseAiohttpAPI class.
+        """
+        self.logger = logger
+
+    def run(self, app, host, port):
+        """
+        Run the server on the specified host and port.
+        """
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self._run_server(app, host, port))
+
+    async def _run_server(self, app, host, port):
+        """
+        Asynchronously run the server and handle shutdown.
+        """
+        # Run server
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, host, port)
+        await site.start()
+        self.logger.info(f"Server started at {host}:{port}")
+
+        # Wait for shutdown signal
+        shutdown_event = asyncio.Event()
+        try:
+            await shutdown_event.wait()
+        except KeyboardInterrupt:
+            self.logger.info(f"Shutting down server {host}:{port}...")
+        finally:
+            await runner.cleanup()

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/pdr_plugin_api.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/api/pdr_plugin_api.py
@@ -44,7 +44,7 @@ class PDRPluginAPI(BaseAiohttpAPI):
         items = self.isolation_mgr.exclude_list.items()
         formatted_items = [f"{item.port_name}: {'infinite' if item.ttl_seconds == 0 else int(max(0, item.remove_time - time.time()))}" for item in items]
         response = EOL.join(formatted_items) + ('' if not formatted_items else EOL)
-        return response, HTTPStatus.OK
+        return self.create_response(response)
 
 
     async def exclude_ports(self, request):
@@ -74,8 +74,8 @@ class PDRPluginAPI(BaseAiohttpAPI):
                     response += f"Port {port_name} added to exclude list for {ttl} seconds"
 
                 response += self.get_port_warning(port_name) + EOL
-    
-        return response, HTTPStatus.OK
+
+        return self.create_response(response)
 
 
     async def include_ports(self, request):
@@ -102,7 +102,7 @@ class PDRPluginAPI(BaseAiohttpAPI):
 
             response += self.get_port_warning(port_name) + EOL
 
-        return response, HTTPStatus.OK
+        return self.create_response(response)
 
 
     def get_request_data(self, request):

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_algo.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_algo.py
@@ -14,15 +14,12 @@ import configparser
 import os
 import logging
 from logging.handlers import RotatingFileHandler
+import threading
 from constants import PDRConstants as Constants
 from isolation_mgr import IsolationMgr
+from api.base_aiohttp_api import BaseAiohttpServer
 from ufm_communication_mgr import UFMCommunicator
 from api.pdr_plugin_api import PDRPluginAPI
-from twisted.web.wsgi import WSGIResource
-from twisted.internet import reactor
-from twisted.web import server
-from utils.flask_server import run_api
-from utils.flask_server.base_flask_api_app import BaseFlaskAPIApp
 from utils.utils import Utils
 
 
@@ -81,19 +78,16 @@ def main():
     logger = create_logger(Constants.LOG_FILE)
     
     algo_loop = IsolationMgr(ufm_client, logger)
-    reactor.callInThread(algo_loop.main_flow)
+    threading.Thread(target=algo_loop.main_flow).start()
 
     try:
         plugin_port = Utils.get_plugin_port(
             port_conf_file='/config/pdr_deterministic_httpd_proxy.conf',
             default_port_value=8977)
 
-        routes = {
-            "": PDRPluginAPI(algo_loop).application
-        }
-
-        app = BaseFlaskAPIApp(routes)
-        run_api(app=app, port_number=int(plugin_port))
+        api = PDRPluginAPI(algo_loop)
+        server = BaseAiohttpServer(logger)
+        server.run(api.application, "127.0.0.1", int(plugin_port))
 
     except Exception as ex:
         print(f'Failed to run the app: {str(ex)}')


### PR DESCRIPTION
## What
Replace the flask framework with aiohttp in PDR plugin

## Why ?
[#4044453](https://redmine.mellanox.com/issues/4044453)

## Testing ?
Automatic tests

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
