### PR TITLE
issue:4071348 Remove call for non-existing function (bug fix for issue 3975912 - secondary telemetry instead of a dynamic instance)

### DIFF
--- a/plugins/pdr_deterministic_plugin/build/Dockerfile
+++ b/plugins/pdr_deterministic_plugin/build/Dockerfile
@@ -10,14 +10,8 @@ ARG CONF_PATH=${BASE_PATH}/conf
 ARG SCRIPTS_PATH=${BASE_PATH}/scripts
 
 EXPOSE 8000
-EXPOSE 8982
 EXPOSE 443
 EXPOSE 9002
-EXPOSE 9003
-EXPOSE 9004
-EXPOSE 9005
-EXPOSE 9006
-EXPOSE 9007
 
 RUN apt-get update && apt-get -y install supervisor python3 python3-pip rsyslog vim curl sudo
 

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -309,9 +309,7 @@ class IsolationMgr:
                     for isolated_port in list(self.isolated_ports.values()):
                         if self.pdr_alg.check_deisolation_conditions(isolated_port):
                             self.eval_deisolate(isolated_port.name)
-                ports_updated = self.update_ports_data()
-                if ports_updated:
-                    self.update_telemetry_session()
+                self.update_ports_data()
                 t_end = time.time()
             #pylint: disable=broad-except
             except Exception as exception:


### PR DESCRIPTION
## What
Remove call for non-existing function update_telemetry_session

## Why ?
Bug fix for issue 3975912 - secondary telemetry instead of a dynamic instance
update_telemetry_session was removed in 3975912

## Testing ?
Automatic tests

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
