### PR TITLE
issue:4061560: [TFS plugin] When the telemetry is unresponsive stream cached data

### DIFF
--- a/plugins/fluentd_telemetry_plugin/.pylintrc
+++ b/plugins/fluentd_telemetry_plugin/.pylintrc
@@ -15,6 +15,7 @@ disable=missing-module-docstring,missing-function-docstring,fixme
 
 [FORMAT]
 max-line-length=140
+max-positional-arguments=10
 
 [BASIC]
 min-public-methods=0

--- a/plugins/fluentd_telemetry_plugin/.pylintrc
+++ b/plugins/fluentd_telemetry_plugin/.pylintrc
@@ -6,6 +6,9 @@ max-public-methods=100
 
 [DESIGN]
 max-attributes=10
+max-args=10
+max-locals=20
+max-module-lines=1500
 
 [MESSAGES CONTROL]
 disable=missing-module-docstring,missing-function-docstring,fixme

--- a/plugins/fluentd_telemetry_plugin/conf/fluentd_telemetry_plugin.cfg
+++ b/plugins/fluentd_telemetry_plugin/conf/fluentd_telemetry_plugin.cfg
@@ -17,6 +17,7 @@ c_fluent_streamer = True
 bulk_streaming = True
 compressed_streaming = False
 stream_only_new_samples = True
+enable_cached_stream_on_telemetry_fail = False
 enabled = False
 
 [logs-config]

--- a/plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json
+++ b/plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json
@@ -115,6 +115,9 @@
         "stream_only_new_samples": {
           "type": "boolean"
         },
+        "enable_cached_stream_on_telemetry_fail": {
+          "type": "boolean"
+        },
         "enabled": {
           "type": "boolean"
         }

--- a/plugins/fluentd_telemetry_plugin/src/streamer.py
+++ b/plugins/fluentd_telemetry_plugin/src/streamer.py
@@ -751,7 +751,7 @@ class UFMTelemetryStreaming(Singleton):
             self._get_port_keys_indexes_from_csv_headers(keys)
         if is_xdr_mode:
             port_key_generator = self._get_xdr_port_id_from_csv_row
-            port_key_generator_args = (normal_port_id_keys_indexes, aggr_port_id_keys_indexes)
+            port_key_generator_args = (normal_port_id_keys_indexes, aggr_port_id_keys_indexes, port_type_key_index)
         else:
             port_key_generator = self._get_port_id_from_csv_row
             port_key_generator_args = (normal_port_id_keys_indexes,)
@@ -875,7 +875,8 @@ class UFMTelemetryStreaming(Singleton):
                 ufm_telemetry_is_prometheus_format = self._check_data_prometheus_format(telemetry_data)
                 logging.info('Start Processing The Received Response From %s', msg_tag)
                 start_time = time.time()
-                data_to_stream, new_data_timestamp, num_of_counters = self._parse_telemetry_prometheus_metrics_to_json(telemetry_data, msg_tag) \
+                data_to_stream, new_data_timestamp, num_of_counters = \
+                    self._parse_telemetry_prometheus_metrics_to_json(telemetry_data, msg_tag) \
                     if ufm_telemetry_is_prometheus_format else \
                     self._parse_telemetry_csv_metrics_to_json(telemetry_data, msg_tag, is_xdr_mode)
                 end_time = time.time()


### PR DESCRIPTION
## What

This PR introduces a new fallback option to stream cached data from the last successful iteration when the telemetry endpoint is unavailable. It also includes several improvements to data caching:
- Centralized Port Key Logic: Moves the logic for generating port keys based on type to shared functions.
- Enhanced Caching: Enables caching even when delta mode is disabled.
- Fallback Streaming: Streams cached data if available when the telemetry endpoint is unresponsive.

## Why ?
The goal is to enhance user experience during telemetry endpoint downtimes
it's part of [MKT. UFM Telemetry] Feature Request [#3929853](https://redmine.mellanox.com/issues/3929853): [Bytedance NDR][Feature Request]: Request UFM TFS Telemetry data(PortXmitDataExtended) to avoid to drop to 0 for Switch

## How ?
Data fetched from telemetry endpoints will be stored (cached) in a map per telemetry. If a telemetry endpoint becomes unavailable, and there was a previous successful iteration, the TFS will stream the cached data instead of not pushing anything.
This option is configurable via a new option in the `/conf` API called `enable_cached_stream_on_telemetry_fail`, which is enabled by default.

## Testing ?
The following scenarios were manually tested:
1. Streaming data with delta mode enabled/disabled to ensure existing functionality is operational.
2. Stopping the telemetry to verify that cached data is forwarded correctly, regardless of delta mode status.
3. Disabling the `enable_cached_stream_on_telemetry_fail` option to confirm that no data is streamed when telemetry is down.

