### PR TITLE
issue:4091669 PDR plugin is not isolate based on LinkDownedCounter measurements

### DIFF
--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/pdr_algorithm.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/pdr_algorithm.py
@@ -24,7 +24,7 @@ class PortData:
     """
     Represents the port data.
     """
-    #pylint: disable=too-many-positional-arguments
+    #pylint: disable=too-many-positional-arguments,too-many-arguments
     def __init__(self, port_name=None, port_num=None, peer=None, node_type=None, active_speed=None, port_width=None, port_guid=None):
         """
         Initialize a new instance of the PortData class.
@@ -470,7 +470,7 @@ class PDRAlgorithm:
 
         return True
 
-    #pylint: disable=too-many-positional-arguments,too-many-locals
+    #pylint: disable=too-many-positional-arguments,too-many-arguments,too-many-locals
     def calc_symbol_ber_rate(self, port_name, port_speed, port_width, col_name, time_delta):
         """
         calculate the symbol BER rate for a given port given the time delta

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/pdr_algorithm.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/pdr_algorithm.py
@@ -24,7 +24,7 @@ class PortData:
     """
     Represents the port data.
     """
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-positional-arguments
     def __init__(self, port_name=None, port_num=None, peer=None, node_type=None, active_speed=None, port_width=None, port_guid=None):
         """
         Initialize a new instance of the PortData class.
@@ -470,7 +470,7 @@ class PDRAlgorithm:
 
         return True
 
-    #pylint: disable=too-many-arguments,too-many-locals
+    #pylint: disable=too-many-positional-arguments,too-many-locals
     def calc_symbol_ber_rate(self, port_name, port_speed, port_width, col_name, time_delta):
         """
         calculate the symbol BER rate for a given port given the time delta

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
@@ -45,8 +45,8 @@ class TelemetryCollector:
             elif telemetry_data is not None:
                 # when we want to keep the abs
                 self.data_store.save(telemetry_data,self.data_store.get_filename_abs())
-        except Exception as exception_error:
-                self.logger.error(f"Failed to store telemetry data with error {exception_error}")
+        except Exception as exception_error: # pylint: disable=broad-exception-caught
+            self.logger.error(f"Failed to store telemetry data with error {exception_error}")
 
         # update previous telemetry data
         if telemetry_data is not None:

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
@@ -36,6 +36,15 @@ class TelemetryCollector:
             telemetry_data = None
 
         # store telemetry data
+        self.store_telemetry_data(telemetry_data)
+
+        # return retrieved data
+        return telemetry_data
+
+    def store_telemetry_data(self, telemetry_data):
+        """
+        Store telemetry data into the file
+        """
         try:
             if self.previous_telemetry_data is not None and telemetry_data is not None:
                 delta = self._get_delta(self.previous_telemetry_data,telemetry_data)
@@ -48,10 +57,9 @@ class TelemetryCollector:
         except Exception as exception_error: # pylint: disable=broad-exception-caught
             self.logger.error(f"Failed to store telemetry data with error {exception_error}")
 
-        # update previous telemetry data
+        # keep telemetry data for next delta calculation
         if telemetry_data is not None:
             self.previous_telemetry_data = telemetry_data
-        return telemetry_data
 
     def _get_delta(self, first_df: pd.DataFrame, second_df:pd.DataFrame):
         merged_df = pd.merge(second_df, first_df, on=self.BASED_COLUMNS, how='inner', suffixes=('', '_x'))

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
@@ -58,9 +58,9 @@ class TelemetryCollector:
         delta_dataframe = pd.DataFrame()
         for _,col in enumerate(second_df.columns):
             col_x = col + "_x"
-            if col not in self.KEY\
-                    and not merged_df[col].apply(lambda x: isinstance(x, str)).any()\
-                    and not merged_df[col_x].apply(lambda x: isinstance(x, str)).any():
+            if col not in self.KEY \
+                    and merged_df[col].dtype != 'object' \
+                    and merged_df[col_x].dtype != 'object':
                 try:
                     delta_dataframe[col] = merged_df[col] - merged_df[col_x]
                 except TypeError:

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
@@ -57,8 +57,10 @@ class TelemetryCollector:
         merged_df = pd.merge(second_df, first_df, on=self.BASED_COLUMNS, how='inner', suffixes=('', '_x'))
         delta_dataframe = pd.DataFrame()
         for _,col in enumerate(second_df.columns):
-            if col not in self.KEY:
-                col_x = col + "_x"
+            col_x = col + "_x"
+            if col not in self.KEY\
+                    and not merged_df[col].apply(lambda x: isinstance(x, str)).any()\
+                    and not merged_df[col_x].apply(lambda x: isinstance(x, str)).any():
                 try:
                     delta_dataframe[col] = merged_df[col] - merged_df[col_x]
                 except TypeError:

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/telemetry_collector.py
@@ -23,34 +23,46 @@ class TelemetryCollector:
         get the telemetry from secondary telemetry, if it in test mode it get from the simulation
         return DataFrame of the telemetry
         """
+        # get telemetry data
         if self.test_mode:
             url = "http://127.0.0.1:9090/csv/xcset/simulated_telemetry"
         else:
             url = f"http://127.0.0.1:{self.SECONDARY_TELEMETRY_PORT}/csv/xcset/{self.SECONDARY_INSTANCE}"
         try:
-            self.logger.info(f"collecting telemetry from {url}.")
+            self.logger.info(f"Collecting telemetry from {url}.")
             telemetry_data = pd.read_csv(url)
         except (pd.errors.ParserError, pd.errors.EmptyDataError, urllib.error.URLError) as connection_error:
-            self.logger.error("failed to get telemetry data from UFM, fetched url=%s. Error: %s",url,connection_error)
+            self.logger.error("Failed to get telemetry data from UFM, fetched url=%s. Error: %s",url,connection_error)
             telemetry_data = None
-        if self.previous_telemetry_data is not None and telemetry_data is not None:
-            delta = self._get_delta(self.previous_telemetry_data,telemetry_data)
-            # when we want to keep only delta
-            if len(delta) > 0:
-                self.data_store.save(delta,self.data_store.get_filename_delta())
-        elif telemetry_data is not None:
-            # when we want to keep the abs
+
+        # store telemetry data
+        try:
+            if self.previous_telemetry_data is not None and telemetry_data is not None:
+                delta = self._get_delta(self.previous_telemetry_data,telemetry_data)
+                # when we want to keep only delta
+                if len(delta) > 0:
+                    self.data_store.save(delta,self.data_store.get_filename_delta())
+            elif telemetry_data is not None:
+                # when we want to keep the abs
+                self.data_store.save(telemetry_data,self.data_store.get_filename_abs())
+        except Exception as exception_error:
+                self.logger.error(f"Failed to store telemetry data with error {exception_error}")
+
+        # update previous telemetry data
+        if telemetry_data is not None:
             self.previous_telemetry_data = telemetry_data
-            self.data_store.save(telemetry_data,self.data_store.get_filename_abs())
         return telemetry_data
 
     def _get_delta(self, first_df: pd.DataFrame, second_df:pd.DataFrame):
         merged_df = pd.merge(second_df, first_df, on=self.BASED_COLUMNS, how='inner', suffixes=('', '_x'))
         delta_dataframe = pd.DataFrame()
-        for index,col in enumerate(second_df.columns):
-            if col not in self.KEY and not isinstance(merged_df.iat[0,index],str):
+        for _,col in enumerate(second_df.columns):
+            if col not in self.KEY:
                 col_x = col + "_x"
-                delta_dataframe[col] = merged_df[col] - merged_df[col_x]
+                try:
+                    delta_dataframe[col] = merged_df[col] - merged_df[col_x]
+                except TypeError:
+                    delta_dataframe[col] = second_df[col]
             else:
                 delta_dataframe[col] = second_df[col]
         return delta_dataframe


### PR DESCRIPTION
## What
Fix for telemetry delta calculation in data collector.
Non-numeric data raises type error exception.

## Why ?
[#4091669](https://redmine.mellanox.com/issues/4091669)
PDR plugin does not isolate based on LinkDownedCounter measurements
Exception raised during telemetry delta calculation of data collector.

## How ?
Handle invalid data in telemetry delta calculation of data collector.
Original delta calculation subtracted two data columns, but validated data types for one (first) item only.
Applied fix validates that all items in both data columns have correct type.

## Testing ?
Automatic and manual tests

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
