### PR TITLE
issue 4061540: Change the default value of enable_cached_stream_on_telemetry_fail to true

### DIFF
--- a/plugins/fluentd_telemetry_plugin/conf/fluentd_telemetry_plugin.cfg
+++ b/plugins/fluentd_telemetry_plugin/conf/fluentd_telemetry_plugin.cfg
@@ -17,7 +17,7 @@ c_fluent_streamer = True
 bulk_streaming = True
 compressed_streaming = False
 stream_only_new_samples = True
-enable_cached_stream_on_telemetry_fail = False
+enable_cached_stream_on_telemetry_fail = True
 enabled = False
 
 [logs-config]


### PR DESCRIPTION
## What
Change the default value of enable_cached_stream_on_telemetry_fail to true

## Why ?
Was committed by mistake with a false value

## Testing ?
None required. It was tested for both true and false values.


## Special triggers
_Use the following phrases as comments to trigger different runs_
