### PR TITLE
4099606: PDR plugin: Traceback: AttributeError: 'dict' object has no attribute 'active_speed' 

### DIFF
--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/data_store.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/data_store.py
@@ -71,7 +71,7 @@ class DataStore:
         :param files: (List) List of files to be removed
         :return: None
         """
-        self.logger.info(f"removing {len(files)} old files")
+        self.logger.info(f"Removing {len(files)} old files")
         for file in files:
             try:
                 if exists(file):
@@ -79,11 +79,11 @@ class DataStore:
             except FileNotFoundError:
                 pass
             except OSError as exc:
-                self.logger.error("failed to remove file %s [%s]", file, exc)
+                self.logger.error("Failed to remove file %s [%s]", file, exc)
 
     def save(self, dataframe:pd.DataFrame, file_name:str) -> None:
         """
         save dataframe to the file name
         """
-        self.logger.info(f"saving data to {file_name}")
+        self.logger.info(f"Saving data to {file_name}")
         dataframe.to_csv(file_name)

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/isolation_mgr.py
@@ -253,7 +253,7 @@ class IsolationMgr:
             for port in meta_data:
                 port_name = port.get(Constants.PORT_NAME)
                 if not self.ports_data.get(port_name):
-                    self.ports_data[port_name] = {}
+                    self.ports_data[port_name] = PortData(port_name)
                     self.update_port_metadata(port_name, port)
                     ports_updated = True
         return ports_updated

--- a/plugins/pdr_deterministic_plugin/ufm_sim_web_service/pdr_algorithm.py
+++ b/plugins/pdr_deterministic_plugin/ufm_sim_web_service/pdr_algorithm.py
@@ -356,9 +356,13 @@ class PDRAlgorithm:
                 return None
             peer_link_downed_rate = self.get_rate(peer_obj, Constants.LNK_DOWNED_COUNTER, peer_link_downed, peer_row_timestamp)
             if peer_link_downed_rate > 0:
-                self.logger.info(f"Isolation issue ({Constants.ISSUE_LINK_DOWN}) detected for port {port_obj.port_name}: "
-                                f"link down counter raised from {old_link_downed} to {link_downed} "
-                                f"and its peer ({port_obj.peer}) link down rate is {peer_link_downed_rate}")
+                info_msg = ""
+                if link_downed == old_link_downed:
+                    info_msg += f"link down counter is {link_downed} with link down rate {link_downed_rate} "
+                else:
+                    info_msg += f"link down counter raised from {old_link_downed} to {link_downed} "
+                info_msg += f"and its peer ({port_obj.peer}) link down rate is {peer_link_downed_rate}"
+                self.logger.info(f"Isolation issue ({Constants.ISSUE_LINK_DOWN}) detected for port {port_obj.port_name}: {info_msg}")
                 return Issue(port_obj.port_name, Constants.ISSUE_LINK_DOWN)
         return None
 


### PR DESCRIPTION
## What
Fix for Traceback: AttributeError: 'dict' object has no attribute 'active_speed' in PDR plugin
Cosmetic changes in logged text messages

## Why ?
[4099606](https://redmine.mellanox.com/issues/4099606)
When plugin is disable and then enabled with changing to topology, there is Traceback with error:
AttributeError: 'dict' object has no attribute 'active_speed' in PDR plugin
[pdr_deterministic_plugin 6.log](https://github.com/user-attachments/files/17210889/pdr_deterministic_plugin.6.log)

## How ?
Object of wrong type has been added to ports_data.
Fix adds object of correct type

## Testing ?
Manual testing for bug fix
Automatic testing for regression

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
