### PR TITLE
issue:4102435: [TFS plugin]: URL `metrics` Prometheus format is not working

### DIFF
--- a/plugins/fluentd_telemetry_plugin/src/streamer.py
+++ b/plugins/fluentd_telemetry_plugin/src/streamer.py
@@ -756,10 +756,6 @@ class UFMTelemetryStreaming(Singleton):
             port_key_generator = self._get_port_id_from_csv_row
             port_key_generator_args = (normal_port_id_keys_indexes,)
 
-        if self.last_streamed_data_sample_per_endpoint.get(msg_tag, None) is None:
-            self.last_streamed_data_sample_per_endpoint[msg_tag] = {}
-
-
         parser_method = self._parse_telemetry_csv_metrics_to_json_with_delta if self.stream_only_new_samples \
             else self._parse_telemetry_csv_metrics_to_json_without_delta
 
@@ -872,6 +868,8 @@ class UFMTelemetryStreaming(Singleton):
             new_data_timestamp = None
             num_of_counters = data_len = 0
             if telemetry_data:
+                if self.last_streamed_data_sample_per_endpoint.get(msg_tag, None) is None:
+                    self.last_streamed_data_sample_per_endpoint[msg_tag] = {}
                 ufm_telemetry_is_prometheus_format = self._check_data_prometheus_format(telemetry_data)
                 logging.info('Start Processing The Received Response From %s', msg_tag)
                 start_time = time.time()


### PR DESCRIPTION
## What
The streaming is broken when the TFS is configured to stream data from the telemetry endpoint with Promethues format (i.e. url=metrics instead of url=csv/metrics)

## Why ?
The map `last_streamed_data_sample_per_endpoint` won't be initialized correctly in the case of Promethues, the fix will make sure that the map will be correctly initialized in all cases (CSV or Prometheus)

To fix [#4102435](https://redmine.mellanox.com/issues/4102435): [TFS plugin]: URL `metrics` Prometheus format is not working 

## Testing ?
Tested manually by configuring the TFS to collect data with url=metrics and ensure the streaming works as expected.
