### PR TITLE
issue: 4197119: Make the threshold work only for primary telemetry

### DIFF
--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/log_analyzers/ibdiagnet2_port_counters_analyzer.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/log_analyzers/ibdiagnet2_port_counters_analyzer.py
@@ -129,7 +129,8 @@ class Ibdiagnet2PortCountersAnalyzer(BaseAnalyzer):
         filtered_data = filtered_data[["type", "timestamp", "data"]]
         filtered_data["data"] = pd.to_numeric(filtered_data["data"], errors="coerce")
 
-        filtered_data = filtered_data[filtered_data["data"] >= threshold]
+        if self.telemetry_type == "primary":
+            filtered_data = filtered_data[filtered_data["data"] >= threshold]
         filtered_data["timestamp"] = pd.to_datetime(
             filtered_data["timestamp"], errors="coerce"
         )


### PR DESCRIPTION
## What
_Make the threshold of telemetry iteration time work only for primary telemetry._ 

## Why ?
_The primary telemetry contains irrelevant samples, but this is not the case for the secondary telemetry._

## How ?
_A condition was added._

## Testing ?
_Tested manually to ensure the output looks the same as before the change._

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
