### PR TITLE
issue: 4207369: EOFError while extracting logs

### DIFF
--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/logs_extraction/tar_extractor.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/logs_extraction/tar_extractor.py
@@ -48,6 +48,7 @@ class DumpFilesExtractor(BaseExtractor):
         failed_extract = set()
         folders_to_remove = set()
         single_log_name, logs_with_dirs = self._split_based_on_dir(files_to_extract)
+
         for member in opened_file:
             base_name = os.path.basename(member.name)
             full_dir_path = os.path.dirname(member.name)
@@ -82,6 +83,8 @@ class DumpFilesExtractor(BaseExtractor):
                         logs_with_dirs[parent_dir_name].discard(original_base_name)
                         if len(logs_with_dirs[parent_dir_name]) == 0:
                             del logs_with_dirs[parent_dir_name]
+
+
 
         files_extracted = files_went_over.difference(failed_extract)
         # When extracting the files from the tar, they are also taken with their
@@ -125,20 +128,39 @@ class DumpFilesExtractor(BaseExtractor):
             ]
             for inner_tar_name in inner_tar_files:
                 with outer_tar.extractfile(inner_tar_name) as inner_tar_stream:
+
+                    # Check if the inner stream can be read
+                    try:
+                        # Read some bytes to verify the file is not corrupted
+                        inner_tar_stream.peek(1)  # Peek at the first byte
+                    except Exception as e:
+                        log.Logger.info(f"Error reading inner tar file {inner_tar_name}: {e}")
+                        continue  # Skip this file if it's invalid
+
                     inner_file_open_mode = (
                         "r:gz" if self.is_gzip_file_obj(inner_tar_stream) else "r:"
                     )
-                    with tarfile.open(
-                        fileobj=inner_tar_stream, mode=inner_file_open_mode
-                    ) as inner_tar:
-                        extracted_files, failed_files = self._get_files_from_tar(
-                            inner_tar,
-                            files_to_extract,
-                            directories_to_extract,
-                            destination,
-                        )
-                        if len(extracted_files) > 0:
-                            return extracted_files, failed_files
+
+                    try:
+
+                        with tarfile.open(
+                            fileobj=inner_tar_stream, mode=inner_file_open_mode
+                        ) as inner_tar:
+                            extracted_files, failed_files = self._get_files_from_tar(
+                                inner_tar,
+                                files_to_extract,
+                                directories_to_extract,
+                                destination,
+                            )
+                            if len(extracted_files) > 0:
+                                return extracted_files, failed_files
+
+
+                    except EOFError as e:
+                        log.logger.info(f"EOFError in inner tar {inner_tar_name}: {e}")
+                        continue  # Handle the EOFError and continue with the next file
+
+
             # If we got to this point, we might have a simple tar, try to extract from it
             return self._get_files_from_tar(
                 outer_tar, files_to_extract, directories_to_extract, destination

--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/logs_extraction/tar_extractor.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/logs_extraction/tar_extractor.py
@@ -134,7 +134,7 @@ class DumpFilesExtractor(BaseExtractor):
                         # Read some bytes to verify the file is not corrupted
                         inner_tar_stream.peek(1)  # Peek at the first byte
                     except Exception as e:
-                        log.Logger.info(f"Error reading inner tar file {inner_tar_name}: {e}")
+                        log.Logger.info("Error reading inner tar file %s: %s", inner_tar_name, e)
                         continue  # Skip this file if it's invalid
 
                     inner_file_open_mode = (
@@ -157,10 +157,8 @@ class DumpFilesExtractor(BaseExtractor):
 
 
                     except EOFError as e:
-                        log.logger.info(f"EOFError in inner tar {inner_tar_name}: {e}")
-                        continue  # Handle the EOFError and continue with the next file
-
-
+                        log.LOGGER.info("EOFError in inner tar %s: %s", inner_tar_name, e)
+                        continue
             # If we got to this point, we might have a simple tar, try to extract from it
             return self._get_files_from_tar(
                 outer_tar, files_to_extract, directories_to_extract, destination

--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/logs_extraction/tar_extractor.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/logs_extraction/tar_extractor.py
@@ -84,8 +84,6 @@ class DumpFilesExtractor(BaseExtractor):
                         if len(logs_with_dirs[parent_dir_name]) == 0:
                             del logs_with_dirs[parent_dir_name]
 
-
-
         files_extracted = files_went_over.difference(failed_extract)
         # When extracting the files from the tar, they are also taken with their
         # directories from inside the tar, there is no way to only take the file
@@ -128,13 +126,14 @@ class DumpFilesExtractor(BaseExtractor):
             ]
             for inner_tar_name in inner_tar_files:
                 with outer_tar.extractfile(inner_tar_name) as inner_tar_stream:
-
                     # Check if the inner stream can be read
                     try:
                         # Read some bytes to verify the file is not corrupted
                         inner_tar_stream.peek(1)  # Peek at the first byte
                     except Exception as e:
-                        log.Logger.info("Error reading inner tar file %s: %s", inner_tar_name, e)
+                        log.LOGGER.info(
+                            "Error reading inner tar file %s: %s", inner_tar_name, e
+                        )
                         continue  # Skip this file if it's invalid
 
                     inner_file_open_mode = (
@@ -142,7 +141,6 @@ class DumpFilesExtractor(BaseExtractor):
                     )
 
                     try:
-
                         with tarfile.open(
                             fileobj=inner_tar_stream, mode=inner_file_open_mode
                         ) as inner_tar:
@@ -155,9 +153,10 @@ class DumpFilesExtractor(BaseExtractor):
                             if len(extracted_files) > 0:
                                 return extracted_files, failed_files
 
-
                     except EOFError as e:
-                        log.LOGGER.info("EOFError in inner tar %s: %s", inner_tar_name, e)
+                        log.LOGGER.info(
+                            "EOFError in inner tar %s: %s", inner_tar_name, e
+                        )
                         continue
             # If we got to this point, we might have a simple tar, try to extract from it
             return self._get_files_from_tar(

--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/logs_extraction/tar_extractor.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/logs_extraction/tar_extractor.py
@@ -126,16 +126,6 @@ class DumpFilesExtractor(BaseExtractor):
             ]
             for inner_tar_name in inner_tar_files:
                 with outer_tar.extractfile(inner_tar_name) as inner_tar_stream:
-                    # Check if the inner stream can be read
-                    try:
-                        # Read some bytes to verify the file is not corrupted
-                        inner_tar_stream.peek(1)  # Peek at the first byte
-                    except Exception as e:
-                        log.LOGGER.info(
-                            "Error reading inner tar file %s: %s", inner_tar_name, e
-                        )
-                        continue  # Skip this file if it's invalid
-
                     inner_file_open_mode = (
                         "r:gz" if self.is_gzip_file_obj(inner_tar_stream) else "r:"
                     )


### PR DESCRIPTION
## What
_Skip corrupted inner tar files._ 

## Why ?
_An EOFError is expected when running the analyzer on a tar file where one of the inner tar files is corrupted, but the outer tar file is valid._

## How ?
_Add checking validity._

## Testing ?
_Manually, run the analyzer and check the output pdf_

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
