### PR TITLE
issue: #4268945: Use class member instead of function call

### DIFF
--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/log_analyzers/ibdiagnet2_port_counters_analyzer.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/log_analyzers/ibdiagnet2_port_counters_analyzer.py
@@ -36,7 +36,7 @@ class Ibdiagnet2PortCountersAnalyzer(BaseAnalyzer):
             ).astype("Int64")
         self._funcs_for_analysis = {
             self.plot_iteration_time_over_time,
-            self.save_last_iterations_time_stats,
+            self.save_iterations_time_stats,
             self.save_first_last_iteration_timestamp,
             self.save_number_of_switches_and_ports,
             self.save_number_of_core_dumps,
@@ -193,11 +193,11 @@ class Ibdiagnet2PortCountersAnalyzer(BaseAnalyzer):
             )
         )
 
-    def save_last_iterations_time_stats(self):
+    def save_iterations_time_stats(self):
         self._dataframes_for_pdf.append(
             (
                 f"{self.telemetry_type} telemetry iteration time",
-                self._iteration_time_stats(),
+                self._iteration_time_stats,
             )
         )
 


### PR DESCRIPTION
## What
_In ibdiagnet2_port_counters_analyzer.py, remove the brackets on line 200._

## Why ?
_Using brackets is incorrect since there’s no function being called. The code should reference the class member instead.
Additionally, rename the function from save_last_iterations_time_stats to save_iterations_time_stats, as it saves general iteration time statistics._
https://redmine.mellanox.com/issues/4268945

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
