### PR TITLE
issue:4276633 Sys log also to redhat

### DIFF
--- a/scripts/ufm_node_health_check/ufm_node_health_check.py
+++ b/scripts/ufm_node_health_check/ufm_node_health_check.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# Copyright © 2013-2025 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
 #
 # This software product is a proprietary product of Nvidia Corporation and its affiliates
 # (the "Company") and all right, title, and interest in and to the software
@@ -37,10 +37,22 @@ def configure_logger():
 
         logger.addHandler(handler)
 
-        syslog_handler = SysLogHandler(address=("/dev/log"))
-        syslog_formatter = logging.Formatter(
-            fmt="ufm_node_health_checker : [%(process)d]: %(levelname)s: %(message)s"
-        )
+        syslog_handler = None
+        try:
+            # First attempt /dev/log (default for most Unix-like systems)
+            syslog_handler = SysLogHandler(address="/dev/log")
+        except Exception:
+            try:
+                # Fallback for Red Hat or others that use /var/run/syslog
+                syslog_handler = SysLogHandler(address="/var/run/syslog")
+            except Exception:
+                logger.warning("Syslog is not available on this system.")
+
+        if syslog_handler:
+            syslog_formatter = logging.Formatter(
+                fmt="ufm_node_health_checker : [%(process)d]: %(levelname)s: %(message)s"
+            )
+
         syslog_handler.setFormatter(syslog_formatter)
         syslog_handler.setLevel(logging.WARNING)
         logger.addHandler(syslog_handler)
@@ -543,9 +555,7 @@ class UFMNodeHealthChecker:
             "DRBD_ROLE"
         )
         if not self.node_type:
-            logger.warning(
-                "Skipping drdb ROLE check since we or an unkown node type"
-            )
+            logger.warning("Skipping drdb ROLE check since we or an unkown node type")
             return False
         if (
             self.node_type == self.MASTER_STRING


### PR DESCRIPTION
## What
Writing sys log messages also to redhat
## Why ?
To support all the OS platforms that UFM can run on

## Testing ?
Run on red had and seen the message in the syslog
## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
