### PR TITLE
issue: 4273578: [TFS Plugin] Upgrading plugin with manage_ufm_plugins.sh upgrade command fails

### DIFF
--- a/plugins/fluentd_telemetry_plugin/scripts/upgrade.sh
+++ b/plugins/fluentd_telemetry_plugin/scripts/upgrade.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-# python3 /opt/ufm/ufm_plugin_tfs/ufm_sdk_tools/src/config_parser_utils/merge_configuration_files.py /config/fluentd_telemetry_plugin.cfg /opt/ufm/ufm_plugin_tfs/fluentd_telemetry_plugin/conf/fluentd_telemetry_plugin.cfg
+python3 /opt/ufm/ufm_plugin_tfs/ufm_sdk_tools/src/config_parser_utils/merge_configuration_files.py /config/fluentd_telemetry_plugin.cfg /opt/ufm/ufm_plugin_tfs/fluentd_telemetry_plugin/conf/fluentd_telemetry_plugin.cfg
 exit $?

--- a/plugins/fluentd_telemetry_plugin/scripts/upgrade.sh
+++ b/plugins/fluentd_telemetry_plugin/scripts/upgrade.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-python3 /opt/ufm/ufm_plugin_tfs/ufm_sdk_tools/src/config_parser_utils/merge_configuration_files.py /config/fluentd_telemetry_conf.cfg /opt/ufm/ufm_plugin_tfs/fluentd_telemetry_plugin/conf/fluentd_telemetry_plugin.cfg
+# python3 /opt/ufm/ufm_plugin_tfs/ufm_sdk_tools/src/config_parser_utils/merge_configuration_files.py /config/fluentd_telemetry_plugin.cfg /opt/ufm/ufm_plugin_tfs/fluentd_telemetry_plugin/conf/fluentd_telemetry_plugin.cfg
 exit $?


### PR DESCRIPTION
## What
_Fix a typo in the TFS upgrade script._ 

## Why ?
_The upgrade command fails due to the typo._
Link to bug: https://redmine.mellanox.com/issues/4273578

## Testing ?
_Manually upgrade and verify that the version has been updated successfully._

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
