### PR TITLE
issue:4282850change logger name for ufm node health tester

### DIFF
--- a/scripts/ufm_node_health_check/ufm_node_health_check.py
+++ b/scripts/ufm_node_health_check/ufm_node_health_check.py
@@ -22,7 +22,7 @@ from typing import List
 
 
 def configure_logger():
-    logger_name = "standby_node_health_checker"
+    logger_name = "ufm_node_health_checker"
     logger = logging.getLogger(logger_name)
 
     if not logger.hasHandlers():


### PR DESCRIPTION
## What
Change logger name
## Why ?
The script is checking master and standby and the logger name should reflect it

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
