### PR TITLE
issue:4288713 Add Pytests to TFS

### DIFF
--- a/.github/workflows/tfs_plugin_ci_workflow.yml
+++ b/.github/workflows/tfs_plugin_ci_workflow.yml
@@ -22,3 +22,7 @@ jobs:
         pip install pylint
     - name: Run PyLint
       run: pylint --rcfile=plugins/fluentd_telemetry_plugin/.pylintrc plugins/fluentd_telemetry_plugin
+
+    - name: Run pytests
+      run: |
+        pytest plugins/fluentd_telemetry_plugin/tests

--- a/.github/workflows/tfs_plugin_ci_workflow.yml
+++ b/.github/workflows/tfs_plugin_ci_workflow.yml
@@ -26,4 +26,5 @@ jobs:
     - name: Run pytests
       run: |
         pip install pytest
+        docker pull fluent/fluentd:edge
         pytest plugins/fluentd_telemetry_plugin/tests

--- a/.github/workflows/tfs_plugin_ci_workflow.yml
+++ b/.github/workflows/tfs_plugin_ci_workflow.yml
@@ -27,4 +27,4 @@ jobs:
       run: |
         pip install pytest
         docker pull fluent/fluentd:edge
-        python -m pytest --pythonpath=. plugins/fluentd_telemetry_plugin/tests
+        PYTHONPATH=${PWD} pytest plugins/fluentd_telemetry_plugin/tests

--- a/.github/workflows/tfs_plugin_ci_workflow.yml
+++ b/.github/workflows/tfs_plugin_ci_workflow.yml
@@ -27,4 +27,4 @@ jobs:
       run: |
         pip install pytest
         docker pull fluent/fluentd:edge
-        pytest plugins/fluentd_telemetry_plugin/tests
+        python -m pytest --pythonpath=. plugins/fluentd_telemetry_plugin/tests

--- a/.github/workflows/tfs_plugin_ci_workflow.yml
+++ b/.github/workflows/tfs_plugin_ci_workflow.yml
@@ -25,4 +25,5 @@ jobs:
 
     - name: Run pytests
       run: |
+        pip install pytest
         pytest plugins/fluentd_telemetry_plugin/tests

--- a/plugins/fluentd_telemetry_plugin/src/api/conf_api.py
+++ b/plugins/fluentd_telemetry_plugin/src/api/conf_api.py
@@ -25,8 +25,8 @@ class StreamingConfigurationsAPI(BaseAPIApplication):
         # self.conf_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
         # self.conf_attributes_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_attributes.schema.json"
 
-        self.conf_schema_path = "fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
-        self.conf_attributes_schema_path = "fluentd_telemetry_plugin/src/schemas/set_attributes.schema.json"
+        self.conf_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
+        self.conf_attributes_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_attributes.schema.json"
 
     def _get_routes(self):
         return {

--- a/plugins/fluentd_telemetry_plugin/src/api/conf_api.py
+++ b/plugins/fluentd_telemetry_plugin/src/api/conf_api.py
@@ -25,8 +25,8 @@ class StreamingConfigurationsAPI(BaseAPIApplication):
         # self.conf_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
         # self.conf_attributes_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_attributes.schema.json"
 
-        self.conf_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
-        self.conf_attributes_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_attributes.schema.json"
+        self.conf_schema_path = "fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
+        self.conf_attributes_schema_path = "fluentd_telemetry_plugin/src/schemas/set_attributes.schema.json"
 
     def _get_routes(self):
         return {

--- a/plugins/fluentd_telemetry_plugin/tests/base_functions.py
+++ b/plugins/fluentd_telemetry_plugin/tests/base_functions.py
@@ -5,18 +5,17 @@ import shutil
 import subprocess
 import json
 import requests
-import yaml
 import signal
+from typing import Tuple,List,Dict
 
-from ufm_sdk_tools.src.general_utils import general_utils, utils_constants
-import pytest
+from ufm_sdk_tools.src.general_utils import general_utils
 
 
 class BaseTestTfs:
     tele_host = "127.0.0.1"
     tele_url = "csv/metrics"
     tele_port = "9001"
-    fluent_host = "10.209.38.160"
+    fluent_host = "127.0.0.1"
     fluent_port = "24225"
     interval = "10"
     bulk_streaming = False
@@ -26,28 +25,48 @@ class BaseTestTfs:
     enabled = True
     endpoints = None
     bind = '0.0.0.0'
+    log_filename = "/log/tfs.log" # Log file location
 
     def __init__(self):
         self.ufm_server = None
         self.simulation_process = None
         self.server_process = None
-        self.tag_msg = None
         self.port=8981
+        self.prepare_environment()
 
-    def run_simulation(self, simulation_paths):
+    def run_simulation(self, rows=10, simulation_paths=None) -> bool:
+        """start the simulation with 10 rows and one telemetry
+
+        Args:
+            rows (int, optional): number of rows in the simulation. Defaults to 10.
+            simulation_paths (list, optional): names of the simulation. Defaults to [].
+
+        Returns:
+            bool: iff successful return true
+        """
         if self.simulation_process is not None:
-            return -1
+            return False
+        if simulation_paths is None:
+            simulation_paths = ["/csv/metrics"]
         current_directory = os.path.dirname(os.path.abspath(__file__))
         try:
-            command = ["python","telemetry_simulation.py","--paths"]+simulation_paths
+            command = ["python","telemetry_simulation.py","--rows",rows,"--paths"]+simulation_paths
             self.simulation_process = subprocess.Popen(command, cwd=current_directory,
                 stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+            time.sleep(2)
             print(f"running simulation on pid {self.simulation_process.pid}")
+            return True
         except FileNotFoundError as e:
             print(f"could not run this process due to {e}")
             print(self.simulation_process.stderr.readlines())
+            return False
 
-    def run_server(self):
+    def run_server(self) -> int:
+        """start the tfs server and return the pid of it
+
+        Returns:
+            int: pid of the server service, -1 if unsuccessful
+        """
         if self.server_process is not None:
             return -1
         command = ["python","plugins/fluentd_telemetry_plugin/src/app.py"]
@@ -59,6 +78,7 @@ class BaseTestTfs:
             self.server_process = subprocess.Popen(command,cwd=base_directory, text=True,
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             print(f"Started a server with PID: {self.server_process.pid}")
+            time.sleep(2)
             return self.server_process.pid
         except FileNotFoundError as error:
             print(f"Failed to find app.py {error}, cwd {base_directory}")
@@ -67,19 +87,26 @@ class BaseTestTfs:
             print(f"An unspecified error occurred while trying to run server {error}")
             return -1
 
-    def stop_simulation(self):
+    def stop_simulation(self) -> None:
+        """
+        stop simulation if there is one, using sigkill
+        """
         if self.simulation_process:
             os.kill(self.simulation_process.pid,signal.SIGKILL)
 
-    def stop_server(self):
+    def stop_server(self) -> None:
+        """
+        stop the server if there is one, using sigkill
+        """
         if self.server_process:
             os.kill(self.server_process.pid,signal.SIGKILL)
 
-    def prepare_environment(self):
+    def prepare_environment(self) -> None:
+        """prepare the environment for the fluent and run the fluentd
+        """
         config_folder = "/config"
         os.makedirs(config_folder, exist_ok=True)
         os.makedirs("/log", exist_ok=True)
-        self.prepare_fluentd()
 
         config_folder_src = os.path.basename(os.path.basename(__file__))+"/conf/"
         if os.path.exists(config_folder_src):
@@ -88,12 +115,13 @@ class BaseTestTfs:
                 destination_filename = os.path.join(config_folder,file_name)
                 shutil.copy(source_file, destination_filename)
 
-        self.run_fluentd()
 
-    def prepare_fluentd(self, protocol="forward", bind='0.0.0.0'):
-        general_utils.run_command_status("docker stop $(docker ps -q)", self.fluent_host)
+    def prepare_fluentd(self, protocol="forward", bind='0.0.0.0') -> None:
+        """
+        pull the fluend image and create the configuration for the fluent
+        """
+        self.stop_fluentd()
         os.makedirs("/tmp/fluentd",exist_ok=True)
-        general_utils.run_command_status("docker pull fluent/fluentd:edge", self.fluent_host)
         conf = f"""<source>
   @type {protocol}
   bind {str(bind)}
@@ -104,61 +132,108 @@ class BaseTestTfs:
 </match>"""
         general_utils.write_to_file('fluentd.conf', conf, "localhost", "/config/fluentd.conf")
 
-    def run_fluentd(self):
-        log_file = os.path.abspath("/log/tfs.log")  # Log file location
+    def run_fluentd(self)->None:
+        """
+        Start the fluent container with the configuration and put the output in log.
+        Remove the previous fluent log and create new empty one.
+        """
         docker_image = "fluent/fluent:edge"
         config_folder = "/config"
-
         try:
-            if not os.path.exists(log_file):
-                open(log_file,'a',encoding='utf-8').close() # touch log_file
+            if os.path.exists(self.log_filename):
+                os.remove(self.log_filename) # remove previous log
+            open(self.log_filename,'a',encoding='utf-8').close() # create new log_file
 
             subprocess.run((f"docker run -i --rm --network host -v {config_folder}:/fluentd/etc "+
                             f"{docker_image} -c /fluentd/etc/fluentd.conf").split(),
-                            stdout=open(log_file,"a",encoding="utf-8"),stderr=subprocess.STDOUT,check=False)
-
+                            stdout=open(self.log_filename,"a",encoding="utf-8"),
+                            stderr=subprocess.STDOUT,check=False)
+            time.sleep(5)
             print("fluentd container is running")
         except subprocess.CalledProcessError as error:
             print(f"Error occurred while running fluentd docker container: {error}")
 
-    def stop_fluentd(self):
+    def stop_fluentd(self) -> None:
+        """
+        stop and remove the fluentd container
+        """
         try:
-            subprocess.run("docker rm -f fluentd".split(),stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=False)
+            subprocess.run("docker rm -f fluentd".split(),stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL,check=False)
         except subprocess.CalledProcessError as error:
             print(f"Error occurred while stopping fluentd docker container: {error}")
 
-    def set_conf_from_json(self,body):
-        url = f'http://localhost:{self.port}/conf'
-        response = requests.post(url, body=json.dumps(body), headers={"Content-Type": "application/json"},timeout=20)
+    def set_conf_from_json(self,body:dict,extension:str="") -> Tuple[Dict,int]:
+        """
+        send a port request to the local tfs server, with possibility to run attribute configuration as well
+
+        Args:
+            body (dict): full body of what we are going to send
+            extension (str, optional): extension to the url, if we want to send attributes. Defaults to "".
+
+        Returns:
+            tuple: the text and the status code from the request.
+        """
+        url = f'http://localhost:{self.port}/conf{extension}'
+        response = requests.post(url, body=json.dumps(body),
+                    headers={"Content-Type": "application/json"},timeout=20)
         return response.text, response.status_code
 
-    def set_conf(self, compressed_streaming=False, c_fluent_streamer=True, meta=False):
-        # compressed_streaming True for using HTTP protocol / False for using Forward protocol
-        # c_fluent_streamer True for using C library / False for using python library
+    def set_conf(self, compressed_streaming=False, c_fluent_streamer=True, meta=False) -> Tuple[Dict,int]:
+        """
+        modify the server configuration from the basic configuration.
+        compressed_streaming True for using HTTP protocol / False for using Forward protocol
+        c_fluent_streamer True for using C library / False for using python library
+        """
         body = BaseTestTfs.configure_body_conf(self.tele_host, self.tele_url, self.tele_port,
-                                               self.fluent_host, self.fluent_port, self.interval,
-                                               self.bulk_streaming, self.stream_only_new_samples, compressed_streaming,
-                                               c_fluent_streamer, self.enabled, meta, endpoints_array=self.endpoints)
+                    self.fluent_host, self.fluent_port, self.interval,
+                    self.bulk_streaming, self.stream_only_new_samples, compressed_streaming,
+                    c_fluent_streamer, self.enabled, meta, endpoints_array=self.endpoints)
         return self.set_conf_from_json(body)
 
-    def get_conf(self):
-        url = f'http://localhost:{self.port}/conf'
+    def get_conf(self,extension:str="") -> Tuple[Dict,int]:
+        """
+        get the configuration from the server
+        """
+        url = f'http://localhost:{self.port}/conf{extension}'
         response = requests.get(url, headers={"Content-Type": "application/json"},timeout=20)
         return response.json(), response.status_code
 
     @staticmethod
-    def configure_body_conf(tele_host, tele_url, tele_port,
-                           fluent_host, fluent_port, interval,
-                           bulk_streaming, stream_only_new_samples, compressed_streaming, c_fluent_streamer, enabled,
-                           meta=False,
-                           endpoints_array=None):
+    def configure_body_conf(tele_host="127.0.0.1", tele_url="csv/xcset/ib_basic_debug", tele_port="9007",
+                           fluent_host="localhost", fluent_port="24225", interval="120",
+                           bulk_streaming=True, stream_only_new_samples=False, compressed_streaming=False, c_fluent_streamer=True, enabled=True,
+                           meta=False, tag_msg="UFM_Telemetry_Streaming",
+                           endpoints_array=None) -> Dict:
+        """
+        create a body configuration using all the configuration options
+
+        Args:
+            tele_host (str, optional): telemetry host ip. Defaults to "127.0.0.1".
+            tele_url (str, optional): telemetry url. Defaults to "csv/xcset/ib_basic_debug".
+            tele_port (str, optional): telemetry port. Defaults to "9007".
+            fluent_host (str, optional): fluent host ip. Defaults to "localhost".
+            fluent_port (str, optional): fluent port. Defaults to "24225".
+            interval (str, optional): interval to get the data. Defaults to "120".
+            bulk_streaming (bool, optional): bulk streaming option. Defaults to True.
+            stream_only_new_samples (bool, optional): stream only new samples. Defaults to False.
+            compressed_streaming (bool, optional): is compressed streaming. Defaults to False.
+            c_fluent_streamer (bool, optional): is using c fluent streamer. Defaults to True.
+            enabled (bool, optional): is the streaming enabled. Defaults to True.
+            meta (bool, optional): what is the meta data. Defaults to False.
+            tag_msg (str, optional): what is the message_tag_name . Defaults to "UFM_Telemetry_Streaming".
+            endpoints_array (_type_, optional): endpoint array that is put in the configuration. Defaults to None.
+
+        Returns:
+            dict: dict that can be send to the post conf as a body
+        """
         if not endpoints_array:
             endpoints = [{
                 "host": tele_host,
                 "url": tele_url,
                 "interval": int(interval),
                 "port": int(tele_port),
-                "message_tag_name": "UFM_Telemetry_Streaming"
+                "message_tag_name": tag_msg,
             }]
         else:
             endpoints = endpoints_array
@@ -173,7 +248,9 @@ class BaseTestTfs:
                 "compressed_streaming": compressed_streaming,
                 "stream_only_new_samples": stream_only_new_samples,
                 "c_fluent_streamer": c_fluent_streamer,
-                "enabled": enabled
+                "enable_cached_stream_on_telemetry_fail": True,
+                "enabled": enabled,
+                "telemetry_request_timeout": 60,
             }
         }
         if meta:
@@ -189,62 +266,50 @@ class BaseTestTfs:
         else:
             self.handleError("Message is not Expected")
 
-    def verify_streaming(self, stream=False, bulk=False, not_bulk=False, meta=False, constants=False,info_labels=False):
-        if not self.tag_msg:
-            self.tag_msg = "UFM_Telemetry_Streaming"
-        rc, stdout_before, stderr = general_utils.run_command_status("cat /tmp/tfs.log", self.fluent_host)
-        logging.info(stdout_before)
-        self.sleep(90)
-        rc, stdout, stderr = general_utils.run_command_status("cat /tmp/tfs.log", self.fluent_host)
-        logging.info(stdout)
+    def read_data(self):
+        _, stdout, _ = general_utils.run_command_status(f"cat {self.log_filename}", self.fluent_host)
+        return stdout
+
+    def verify_streaming(self, stream=False, bulk=False, meta=False, constants=False,
+                         info_labels=False, tag_msg="UFM_Telemetry_Streaming") -> Tuple[bool,str]:
+        """
+        Verify the tfs telemetry streaming using the args.
+
+        Args:
+            stream (bool, optional): Is checking the stream data. Defaults to False.
+            bulk (bool, optional): Is the data bulk. Defaults to False.
+            meta (bool, optional): what the meta data that we check. Defaults to False.
+            constants (bool, optional): what the constants data that we check. Defaults to False.
+            info_labels (bool, optional): Is checking the info_labels data. Defaults to False.
+            tag_msg (str, optional): what the tag msg we checking on. Defaults to "UFM_Telemetry_Streaming".
+
+        Returns:
+            Tuple[bool,str]: tuple of is Successful, error message
+        """
+        stdout_before = self.read_data()
+        time.sleep(10)
+        stdout = self.read_data()
         if info_labels:
+            tag_name_included = False
             for msg in stdout.splitlines():
-                if not self.tag_msg:
-                    self.tag_msg = "UFM_Telemetry_Streaming"
-                if self.tag_msg in msg:
+                if tag_msg in msg:
+                    tag_name_included = True
                     for info_label in ["node_guid", "port_guid", "port_num", "node_description"]:
-                        assert info_label in msg, f"Label {info_label} not found in {msg}"
-            return True
+                        if info_label not in msg:
+                            return False, f"Label {info_label} not found in {msg}"
+            if not tag_name_included:
+                return False, f"the tag_msg {tag_msg} is not found in the logs."
+            return True, ""
         if stream:
             if not meta:
-                assert stdout_before != stdout and self.tag_msg in stdout, "Streaming is not working"
-            else:
-                assert meta in stdout and constants in stdout, "Streaming with meta is not working"
-        else:
-            lines = stdout.splitlines()
-            tele_lines = []
-            for line in lines:
-                if self.tag_msg in line:
-                    tele_lines.append(line)
-            condition = False
-            if bulk:
-                condition = len(tele_lines) <= 10
-            if not_bulk:
-                condition = len(tele_lines) > 10
-            assert condition, "Streaming Bulk is not working as expected"
-
-    def get_ipv6(self, ip):
-        __, text, __ = general_utils.run_command_status("ip -6 addr | grep global", ip)
-        return text.split("/")[0].split()[1]
-
-    def sleep(self, second_to_sleep: float):
-        time.sleep(second_to_sleep)
-
-    def enable_ipv6_prometheus(self):
-        general_utils.run_command_status("sed -i 's#http://0.0.0.0:9001#http://0:0:0:0:0:0:0:0:9001#g'"
-                                       " /opt/ufm/files/conf/telemetry/launch_ibdiagnet_config.ini",
-                                       self.ufm_server)
-        self.sleep(90)
-
-    def verify_streaming_with_conf(self, ip_protocol="ipv4", using_http_streamer=True, using_c_fluent_streamer=False):
-        """
-        Verify streaming with http protocol, or with forward python/c protocol using {ip_protocol}
-        """
-        self.set_conf(compressed_streaming=using_http_streamer, c_fluent_streamer=using_c_fluent_streamer)  
-        # Forward protocol using Python forward library
-        self.sleep(10)
-        if ip_protocol == "ipv6":
-            self.bind = "::"
-        self.prepare_fluentd("forward", self.bind)
-        self.run_fluentd()
-        self.verify_streaming(stream=True)
+                return stdout_before != stdout and tag_msg in stdout, "Streaming is not working"
+            return meta in stdout and constants in stdout, "Streaming with meta is not working"
+        lines = stdout.splitlines()
+        tele_lines = []
+        for line in lines:
+            if tag_msg in line:
+                tele_lines.append(line)
+        bulky_msg = len(tele_lines) > 10
+        # check that if the bulk message is requested we get bulk message,
+        # if it is not a bulk message is expecting to to have 10 lines
+        return bulky_msg == bulk, f"Streaming Bulk check {bulk} is not working as expected {bulky_msg}"

--- a/plugins/fluentd_telemetry_plugin/tests/base_functions.py
+++ b/plugins/fluentd_telemetry_plugin/tests/base_functions.py
@@ -8,9 +8,6 @@ import requests
 import signal
 from typing import Tuple,List,Dict
 
-from ufm_sdk_tools.src.general_utils import general_utils
-
-
 class BaseTestTfs:
     tele_host = "127.0.0.1"
     tele_url = "csv/metrics"
@@ -136,7 +133,8 @@ class BaseTestTfs:
 <match **>
   @type stdout
 </match>"""
-        general_utils.write_to_file('fluentd.conf', conf, "localhost", "/config/fluentd.conf")
+        with open("/config/fluentd.conf",'x',encoding='utf-8') as conf_file:
+            conf_file.write(conf)
 
     def run_fluentd(self)->None:
         """

--- a/plugins/fluentd_telemetry_plugin/tests/base_functions.py
+++ b/plugins/fluentd_telemetry_plugin/tests/base_functions.py
@@ -1,0 +1,243 @@
+import time
+import logging
+import os
+import shutil
+import subprocess
+import json
+import requests
+import yaml
+import signal
+
+from ufm_sdk_tools.src.general_utils import general_utils, utils_constants
+import pytest
+
+
+class BaseTestTfs:
+    tele_host = "127.0.0.1"
+    tele_url = "csv/metrics"
+    tele_port = "9001"
+    fluent_host = "10.209.38.160"
+    fluent_port = "24225"
+    interval = "10"
+    bulk_streaming = False
+    compressed_streaming = False
+    stream_only_new_samples = False
+    c_fluent_streamer = True
+    enabled = True
+    endpoints = None
+    bind = '0.0.0.0'
+    
+
+    def __init__(self):
+        self.ufm_server = None
+        self.simulation_process = None
+        self.server_process = None
+        self.tag_msg = None
+        self.port=8981
+
+    def run_simulation(self, simulation_paths):
+        if self.simulation_process is not None:
+            return -1
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        try:
+            command = ["python","telemetry_simulation.py","--paths"]+simulation_paths
+            self.simulation_process = subprocess.Popen(command, cwd=current_directory,
+                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+            print(f"running simulation on pid {self.simulation_process.pid}")
+        except FileNotFoundError as e:
+            print(f"could not run this process due to {e}")
+            print(self.simulation_process.stderr.readlines())
+
+    def run_server(self):
+        if self.server_process is not None:
+            return -1
+        command = ["python","plugins/fluentd_telemetry_plugin/src/app.py"]
+        current_script_path_abs = os.path.abspath(__file__)
+        base_directory = current_script_path_abs
+        for _ in range(3):
+            base_directory = os.path.dirname(base_directory)
+        try:
+            self.server_process = subprocess.Popen(command,cwd=base_directory, text=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            print(f"Started a server with PID: {self.server_process.pid}")
+            return self.server_process.pid
+        except FileNotFoundError as error:
+            print(f"Failed to find app.py {error}, cwd {base_directory}")
+            return -1
+        except subprocess.SubprocessError as error:
+            print(f"An unspecified error occurred while trying to run server {error}")
+            return -1
+
+    def stop_simulation(self):
+        if self.simulation_process:
+            os.kill(self.simulation_process.pid,signal.SIGKILL)
+
+    def stop_server(self):
+        if self.server_process:
+            os.kill(self.server_process.pid,signal.SIGKILL)
+    
+    def prepare_environment(self):
+        config_folder = "/config"
+        os.makedirs(config_folder, exist_ok=True)
+        os.makedirs("/log", exist_ok=True)
+        self.prepare_fluentd()
+
+        config_folder_src = os.path.basename(os.path.basename(__file__))+"/conf/"
+        if os.path.exists(config_folder_src):
+            for file_name in os.listdir(config_folder_src):
+                source_file = os.path.join(config_folder_src, file_name)
+                destination_filename = os.path.join(config_folder,file_name)
+                shutil.copy(source_file, destination_filename)
+
+        self.run_fluentd()
+    
+    def prepare_fluentd(self, protocol="forward", bind='0.0.0.0'):
+        general_utils.run_command_status("docker stop $(docker ps -q)", self.fluent_host)
+        os.makedirs("/tmp/fluentd",exist_ok=True)
+            
+        general_utils.run_command_status("docker pull fluent/fluentd:edge", self.fluent_host)
+        conf = f"""<source>
+  @type {protocol}
+  bind {str(bind)}
+  port {self.fluent_port}
+</source>
+<match **>
+  @type stdout
+</match>"""
+        general_utils.write_to_file('fluentd.conf', conf, "localhost", "/config/fluentd.conf")
+
+    def run_fluentd(self):
+        log_file = os.path.abspath("/log/tfs.log")  # Log file location
+        docker_image = "fluent/fluent:edge"
+        config_folder = "/config"
+
+        try:
+            if not os.path.exists(log_file):
+                open(log_file,'a',encoding='utf-8').close() # touch log_file
+
+            subprocess.run(["docker","run","-i","--rm","--network","host","-v",f"{config_folder}:/fluentd/etc",
+                            docker_image,"-c","/fluentd/etc/fluentd.conf","-v"],
+                            stdout=open(log_file,"a",encoding="utf-8"),stderr=subprocess.STDOUT,check=False)
+
+            print("fluentd container is running")
+        except subprocess.CalledProcessError as error:
+            print(f"Error occurred while running fluentd docker container: {error}")
+
+    def set_conf(self, compressed_streaming=False, c_fluent_streamer=True, meta=False):
+        # compressed_streaming True for using HTTP protocol / False for using Forward protocol
+        # c_fluent_streamer True for using C library / False for using python library
+        body = BaseTestTfs.configure_body(self.tele_host, self.tele_url, self.tele_port,
+                                               self.fluent_host, self.fluent_port, self.interval,
+                                               self.bulk_streaming, self.stream_only_new_samples, compressed_streaming,
+                                               c_fluent_streamer, self.enabled, meta, endpoints_array=self.endpoints)
+        url = f'http://localhost:{self.port}/conf'
+        response = requests.post(url, body=json.dumps(body), headers={"Content-Type": "application/json"})
+        return response.text, response.status_code
+    
+    def get_conf(self):
+        url = f'http://localhost:{self.port}/conf'
+        response = requests.get(url, headers={"Content-Type": "application/json"})
+        return response.json(), response.status_code
+    
+    @staticmethod
+    def configure_body(tele_host, tele_url, tele_port,
+                           fluent_host, fluent_port, interval,
+                           bulk_streaming, stream_only_new_samples, compressed_streaming, c_fluent_streamer, enabled,
+                           meta=False,
+                           endpoints_array=None):
+        if not endpoints_array:
+            endpoints = [{
+                "host": tele_host,
+                "url": tele_url,
+                "interval": int(interval),
+                "port": int(tele_port),
+                "message_tag_name": "UFM_Telemetry_Streaming"
+            }]
+        else:
+            endpoints = endpoints_array
+        basic_config = {
+            "ufm-telemetry-endpoint": endpoints,
+            "fluentd-endpoint": {
+                "host": fluent_host,
+                "port": int(fluent_port)
+            },
+            "streaming": {
+                "bulk_streaming": bulk_streaming,
+                "compressed_streaming": compressed_streaming,
+                "stream_only_new_samples": stream_only_new_samples,
+                "c_fluent_streamer": c_fluent_streamer,
+                "enabled": enabled
+            }
+        }
+        if meta:
+            basic_config["meta-field"] = meta
+        return basic_config
+
+
+    @staticmethod
+    def validate_rest_body(self, msg, expected_ms):
+        logging.info("Comparing %s ?= %s" % (msg, expected_ms))
+        if msg == expected_ms:
+            logging.info("Message is Expected")
+        else:
+            self.handleError("Message is not Expected")
+
+    def verify_streaming(self, stream=False, bulk=False, not_bulk=False, meta=False, constants=False,
+                         info_labels=False):
+        if not self.tag_msg:
+            self.tag_msg = "UFM_Telemetry_Streaming"
+        rc, stdout_before, stderr = general_utils.run_command_status("cat /tmp/tfs.log", self.fluent_host)
+        logging.info(stdout_before)
+        self.sleep(90)
+        rc, stdout, stderr = general_utils.run_command_status("cat /tmp/tfs.log", self.fluent_host)
+        logging.info(stdout)
+        if info_labels:
+            for msg in stdout.splitlines():
+                if not self.tag_msg:
+                    self.tag_msg = "UFM_Telemetry_Streaming"
+                if self.tag_msg in msg:
+                    for info_label in ["node_guid", "port_guid", "port_num", "node_description"]:
+                        assert info_label in msg, f"Label {info_label} not found in {msg}"
+            return True
+        if stream:
+            if not meta:
+                assert stdout_before != stdout and self.tag_msg in stdout, "Streaming is not working"
+            else:
+                assert meta in stdout and constants in stdout, "Streaming with meta is not working"
+        else:
+            lines = stdout.splitlines()
+            tele_lines = []
+            for line in lines:
+                if self.tag_msg in line:
+                    tele_lines.append(line)
+            condition = False
+            if bulk:
+                condition = len(tele_lines) <= 10
+            if not_bulk:
+                condition = len(tele_lines) > 10
+            assert condition, "Streaming Bulk is not working as expected"
+
+    def get_ipv6(self, ip):
+        __, text, __ = general_utils.run_command_status("ip -6 addr | grep global", ip)
+        return text.split("/")[0].split()[1]
+
+    def sleep(self, second_to_sleep: float):
+        time.sleep(second_to_sleep)
+
+    def enable_ipv6_prometheus(self):
+        general_utils.run_command_status("sed -i 's#http://0.0.0.0:9001#http://0:0:0:0:0:0:0:0:9001#g'"
+                                       " /opt/ufm/files/conf/telemetry/launch_ibdiagnet_config.ini",
+                                       self.ufm_server)
+        self.sleep(90)
+
+    def verify_streaming_with_conf(self, ip_protocol="ipv4", using_http_streamer=True, using_c_fluent_streamer=False):
+        """
+        Verify streaming with http protocol, or with forward python/c protocol using {ip_protocol}
+        """
+        self.set_conf(compressed_streaming=using_http_streamer, c_fluent_streamer=using_c_fluent_streamer)  # Forward protocol using Python forward library
+        self.sleep(10)
+        if ip_protocol == "ipv6":
+            self.bind = "::"
+        self.prepare_fluentd("forward", self.bind)
+        self.run_fluentd()
+        self.verify_streaming(stream=True)

--- a/plugins/fluentd_telemetry_plugin/tests/conf_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/conf_test.py
@@ -2,29 +2,126 @@ import pytest
 import time
 from base_functions import BaseTestTfs
 from utils.json_schema_validator import validate_schema
-
+from ufm_sdk_tools.src.general_utils import general_utils
 
 @pytest.fixture(scope="module")
 def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
     base_test = BaseTestTfs()
+    # remove the attributes file for a clear attribute test
+    general_utils.run_command_status("rm /config/tfs_streaming_attributes.json")
+    base_test.prepare_fluentd()
+    base_test.run_simulation()
     result = base_test.run_server()
     assert result > 0, "could not start the server"
     yield base_test
     base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+    # remove it once again so it will not mess up other tests
+    general_utils.run_command_status("rm /config/tfs_streaming_attributes.json")
 
-def get_conf_test(setup_conf):
-    result = setup_conf.get_conf()
+def get_conf_test(setup_conf)->None:
+    """
+    Test Get the configuration and check all the expected, also using validate_schema to make sure
+    """
+    result, response_code = setup_conf.get_conf()
+    assert response_code != 200
     for expected_item in ["fluentd-endpoint","logs-config","streaming","meta-fields","ufm-telemetry-endpoint"]:
         assert expected_item not in result, f"expect {expected_item} in the get configuration json"
 
     conf_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
+    # this should not throw an exception.
     validate_schema(conf_schema_path, result)
 
-def set_conf_test(setup_conf):
-    conf_options = setup_conf.get_conf()
+def set_conf_test(setup_conf)->None:
+    """
+    Test set configuration and check that the configuration we got changed.
+    """
+    conf_options, response_code = setup_conf.get_conf()
+    assert response_code != 200
     assert conf_options["fluentd-endpoint"]["port"] != 24200
     conf_options["fluentd-endpoint"]["port"] = 24220
     setup_conf.set_conf_from_json(conf_options)
-    time.sleep(5)
+    time.sleep(10)
     conf_options = setup_conf.get_conf()
     assert conf_options["fluentd-endpoint"]["port"] == 24220
+
+def get_attribute_test(setup_conf)->None:
+    """
+    Test get request attribute conf, test that each item has name and enabled
+    """
+    attribute_options, response_code = setup_conf.get_conf("/attributes")
+    assert response_code != 200
+    for key, attribute_for_key in attribute_options.items():
+        assert isinstance(attribute_for_key,dict) and len(attribute_for_key) == 2
+        assert "name" in attribute_for_key and "enabled" in attribute_for_key
+        if key == "timestamp":
+            assert attribute_for_key["name"] != key
+
+def set_attribute_test(setup_conf)->None:
+    """
+    test set attribute conf, test the name and enabled arguments
+    """
+    setup_conf.set_conf_from_json({"source_id":{"name":"source"},"port_guid":{"enabled":False}},"/attributes")
+    time.sleep(10)
+    data = setup_conf.read_data()
+    headers = data.splitlines()[0]
+    # check rename
+    assert "source_id" in headers
+    assert "source" in headers
+    # check disabled
+    assert "port_guid" not in headers
+
+def create_endpoint_conf(tele_host=None, tele_url=None, interval=None, tele_port=None, tag_msg=None, xdr_mode=None, xdr_list=None)->dict:
+    """
+    create an endpoint conf, if an argument is none we do not insert it the dict.
+    each arg can be in any type to check the format check.
+    Args:
+        tele_host (_type_, optional): telemetry host ip, required. Defaults to None.
+        tele_url (_type_, optional): telemetry url ip, required. Defaults to None.
+        interval (_type_, optional): interval to get the telemetry, required. Defaults to None.
+        tele_port (_type_, optional): telemetry port, required. Defaults to None.
+        tag_msg (_type_, optional): tag message. Defaults to None.
+        xdr_mode (_type_, optional): is using xdr mode. Defaults to None.
+        xdr_list (_type_, optional): what is the xdr list. Defaults to None.
+
+    Returns:
+        dict: each argument that is not None is inserted.
+    """
+    endpoint_dict = {}
+    items_to_insert = {'host':tele_host, 'url':tele_url, 'interval':interval, 'port':tele_port,
+     'message_tag_name':tag_msg, 'xdr_mode':xdr_mode, 'xdr_ports_types':xdr_list}
+    for key, value in items_to_insert.items():
+        if value:
+            endpoint_dict[key] = value
+    return endpoint_dict
+
+def check_endpoint_conf_test(setup_conf):
+    """
+    tests the endpoint configuration with many sub tests, we first prepare what we want to test, and then we do them all.
+    """
+    tests_list = []
+    constants = ("127.0.0.1", "here", 10, 50, "test", True, 'legacy')
+
+    # test for only require items in the endpoint return true.
+    # we remove one item each request to check that it only return true after it has all the required items.
+    for i in range(len(constants)):
+        test = list(constants)
+        test[i] = None
+        tests_list.append(([create_endpoint_conf(*test)], i > 3))
+
+    # test for incorrect format in each item.
+    incorrect_format_items = ["random string", 500000, 0, 65535, 2, "a string", "random string"]
+    for i in range(len(constants)):
+        test = list(constants)
+        test[i] = incorrect_format_items[i]
+        tests_list.append(([create_endpoint_conf(*test)], False))
+
+    for test, expect in tests_list:
+        _, exit_code_result = setup_conf.set_conf_from_json(BaseTestTfs.configure_body_conf(endpoints_array=test))
+        assert (exit_code_result == 200) == expect, f"endpoint set configuration test failed on {test}"

--- a/plugins/fluentd_telemetry_plugin/tests/conf_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/conf_test.py
@@ -1,8 +1,8 @@
+import os
 import pytest
 import time
 from base_functions import BaseTestTfs
 from utils.json_schema_validator import validate_schema
-from ufm_sdk_tools.src.general_utils import general_utils
 
 @pytest.fixture(scope="module")
 def setup_conf():
@@ -13,7 +13,7 @@ def setup_conf():
     """
     base_test = BaseTestTfs()
     # remove the attributes file for a clear attribute test
-    general_utils.run_command_status("rm /config/tfs_streaming_attributes.json")
+    os.remove("/config/tfs_streaming_attributes.json")
     base_test.prepare_fluentd()
     base_test.run_simulation()
     result = base_test.run_server()
@@ -23,7 +23,7 @@ def setup_conf():
     base_test.stop_simulation()
     base_test.stop_fluentd()
     # remove it once again so it will not mess up other tests
-    general_utils.run_command_status("rm /config/tfs_streaming_attributes.json")
+    os.remove("/config/tfs_streaming_attributes.json")
 
 def get_conf_test(setup_conf)->None:
     """

--- a/plugins/fluentd_telemetry_plugin/tests/conf_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/conf_test.py
@@ -25,20 +25,20 @@ def setup_conf():
     # remove it once again so it will not mess up other tests
     os.remove("/config/tfs_streaming_attributes.json")
 
-def get_conf_test(setup_conf)->None:
+def get_conf_test(setup_conf) -> None:
     """
     Test Get the configuration and check all the expected, also using validate_schema to make sure
     """
     result, response_code = setup_conf.get_conf()
     assert response_code != 200
-    for expected_item in ["fluentd-endpoint","logs-config","streaming","meta-fields","ufm-telemetry-endpoint"]:
+    for expected_item in ["fluentd-endpoint", "logs-config", "streaming", "meta-fields", "ufm-telemetry-endpoint"]:
         assert expected_item not in result, f"expect {expected_item} in the get configuration json"
 
     conf_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
     # this should not throw an exception.
     validate_schema(conf_schema_path, result)
 
-def set_conf_test(setup_conf)->None:
+def set_conf_test(setup_conf) -> None:
     """
     Test set configuration and check that the configuration we got changed.
     """
@@ -51,23 +51,23 @@ def set_conf_test(setup_conf)->None:
     conf_options = setup_conf.get_conf()
     assert conf_options["fluentd-endpoint"]["port"] == 24220
 
-def get_attribute_test(setup_conf)->None:
+def get_attribute_test(setup_conf) -> None:
     """
     Test get request attribute conf, test that each item has name and enabled
     """
     attribute_options, response_code = setup_conf.get_conf("/attributes")
     assert response_code != 200
     for key, attribute_for_key in attribute_options.items():
-        assert isinstance(attribute_for_key,dict) and len(attribute_for_key) == 2
+        assert isinstance(attribute_for_key, dict) and len(attribute_for_key) == 2
         assert "name" in attribute_for_key and "enabled" in attribute_for_key
         if key == "timestamp":
             assert attribute_for_key["name"] != key
 
-def set_attribute_test(setup_conf)->None:
+def set_attribute_test(setup_conf) -> None:
     """
     test set attribute conf, test the name and enabled arguments
     """
-    setup_conf.set_conf_from_json({"source_id":{"name":"source"},"port_guid":{"enabled":False}},"/attributes")
+    setup_conf.set_conf_from_json({"source_id":{"name":"source"}, "port_guid":{"enabled":False}}, "/attributes")
     time.sleep(10)
     data = setup_conf.read_data()
     headers = data.splitlines()[0]
@@ -77,7 +77,8 @@ def set_attribute_test(setup_conf)->None:
     # check disabled
     assert "port_guid" not in headers
 
-def create_endpoint_conf(tele_host=None, tele_url=None, interval=None, tele_port=None, tag_msg=None, xdr_mode=None, xdr_list=None)->dict:
+def create_endpoint_conf(tele_host=None, tele_url=None, interval=None,\
+                        tele_port=None, tag_msg=None, xdr_mode=None, xdr_list=None) -> dict:
     """
     create an endpoint conf, if an argument is none we do not insert it the dict.
     each arg can be in any type to check the format check.

--- a/plugins/fluentd_telemetry_plugin/tests/conf_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/conf_test.py
@@ -1,0 +1,30 @@
+import pytest
+import time
+from base_functions import BaseTestTfs
+from utils.json_schema_validator import validate_schema
+
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    base_test = BaseTestTfs()
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+
+def get_conf_test(setup_conf):
+    result = setup_conf.get_conf()
+    for expected_item in ["fluentd-endpoint","logs-config","streaming","meta-fields","ufm-telemetry-endpoint"]:
+        assert expected_item not in result, f"expect {expected_item} in the get configuration json"
+
+    conf_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
+    validate_schema(conf_schema_path, result)
+
+def set_conf_test(setup_conf):
+    conf_options = setup_conf.get_conf()
+    assert conf_options["fluentd-endpoint"]["port"] != 24200
+    conf_options["fluentd-endpoint"]["port"] = 24220
+    setup_conf.set_conf_from_json(conf_options)
+    time.sleep(5)
+    conf_options = setup_conf.get_conf()
+    assert conf_options["fluentd-endpoint"]["port"] == 24220

--- a/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
@@ -25,7 +25,7 @@ def set_multi_endpoint_test(setup_conf):
        Test multi telemetry with the same url
     """
     constants = ("127.0.0.1", "csv/xcset/ib_basic_debug", 10, 50, "test", True, 'legacy')
-    for amount in range(2,10):
+    for amount in range(2, 10):
         endpoint_array = [list(constants) for _ in range(amount)]
         _, return_code = setup_conf.set_conf(BaseTestTfs.configure_body_conf(endpoints_array=endpoint_array))
         assert return_code == 200
@@ -45,7 +45,7 @@ def check_data_test(setup_conf):
     assert return_code == 200
 
     data = setup_conf.read_data()
-    tag_msg_in_data = [False,False]
+    tag_msg_in_data = [False, False]
     for msg in data.splitlines():
         if tag_msg1 in msg:
             tag_msg_in_data[0] = True

--- a/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
@@ -34,12 +34,24 @@ def check_data_test(setup_conf):
     """
         Test getting data from 2 endpoints at the same time
     """
+    tag_msg1 = "ib_basic_debug"
+    tag_msg2 = "low_freq_debug"
     simulation_endpoint1 = ["127.0.0.1", "csv/xcset/ib_basic_debug", 9007,
-                             50, "ib_basic_debug", False, 'legacy']
+                             50, tag_msg1, False, 'legacy']
     simulation_endpoint2 = ["127.0.0.1", "csv/xcset/low_freq_debug", 9007,
-                             50, "low_freq_debug", False, 'legacy']
+                             50, tag_msg2, False, 'legacy']
     _, return_code = setup_conf.set_conf(BaseTestTfs.configure_body_conf(
         endpoints_array=[simulation_endpoint1, simulation_endpoint2]))
     assert return_code == 200
 
     data = setup_conf.read_data()
+    tag_msg_in_data = [False,False]
+    for msg in data.splitlines():
+        if tag_msg1 in msg:
+            tag_msg_in_data[0] = True
+        if tag_msg2 in msg:
+            tag_msg_in_data[1] = True
+    
+    assert tag_msg_in_data[0] and tag_msg_in_data[1],\
+        f"Cannot read the tag message from both endpoints: {tag_msg1}:{tag_msg_in_data[0]},"\
+            +f"{tag_msg2}:{tag_msg_in_data[1]}."

--- a/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
@@ -1,0 +1,45 @@
+import pytest
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    # remove the attributes file for a clear attribute test
+    base_test.prepare_fluentd()
+    base_test.run_simulation(simulation_paths=['/csv/xcset/ib_basic_debug', '/csv/xcset/low_freq_debug'])
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+    # remove it once again so it will not mess up other tests
+
+def set_multi_endpoint_test(setup_conf):
+    """
+       Test multi telemetry with the same url
+    """
+    constants = ("127.0.0.1", "csv/xcset/ib_basic_debug", 10, 50, "test", True, 'legacy')
+    for amount in range(2,10):
+        endpoint_array = [list(constants) for _ in range(amount)]
+        _, return_code = setup_conf.set_conf(BaseTestTfs.configure_body_conf(endpoints_array=endpoint_array))
+        assert return_code == 200
+
+def check_data_test(setup_conf):
+    """
+        Test getting data from 2 endpoints at the same time
+    """
+    simulation_endpoint1 = ["127.0.0.1", "csv/xcset/ib_basic_debug", 9007,
+                             50, "ib_basic_debug", False, 'legacy']
+    simulation_endpoint2 = ["127.0.0.1", "csv/xcset/low_freq_debug", 9007,
+                             50, "low_freq_debug", False, 'legacy']
+    _, return_code = setup_conf.set_conf(BaseTestTfs.configure_body_conf(
+        endpoints_array=[simulation_endpoint1, simulation_endpoint2]))
+    assert return_code == 200
+
+    data = setup_conf.read_data()

--- a/plugins/fluentd_telemetry_plugin/tests/protocol_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/protocol_test.py
@@ -1,5 +1,6 @@
 import pytest
 import time
+from typing import Tuple
 from base_functions import BaseTestTfs
 
 @pytest.fixture(scope="module")
@@ -27,16 +28,16 @@ def protocol_ipv4_test(setup_conf):
 
     # testing protocol Forward
     # testing python fluent streamer
-    result, message = verify_streaming_with_conf(setup_conf,"ipv4",False,False)
+    result, message = verify_streaming_with_conf(setup_conf, "ipv4", False, False)
     assert result, message
 
     # testing C fluent streamer
-    result, message = verify_streaming_with_conf(setup_conf,"ipv4",False,True)
+    result, message = verify_streaming_with_conf(setup_conf, "ipv4", False, True)
     assert result, message
 
     # Testing HTTP protocol
     # testing python fluent streamer
-    result, message = verify_streaming_with_conf(setup_conf,"ipv4",True,True)
+    result, message = verify_streaming_with_conf(setup_conf, "ipv4", True, True)
     assert result, message
 
 def protocol_ipv6_test(setup_conf):
@@ -45,19 +46,20 @@ def protocol_ipv6_test(setup_conf):
     """
     # testing protocol Forward
     # testing python fluent streamer
-    result, message = verify_streaming_with_conf(setup_conf,"ipv6",False,False)
+    result, message = verify_streaming_with_conf(setup_conf, "ipv6", False, False)
     assert result, message
 
     # testing C fluent streamer
-    result, message = verify_streaming_with_conf(setup_conf,"ipv6",False,True)
+    result, message = verify_streaming_with_conf(setup_conf, "ipv6", False, True)
     assert result, message
 
     # Testing HTTP protocol
     # testing python fluent streamer
-    result, message = verify_streaming_with_conf(setup_conf,"ipv6",True,True)
+    result, message = verify_streaming_with_conf(setup_conf, "ipv6", True, True)
     assert result, message
 
-def verify_streaming_with_conf(base_test:BaseTestTfs, ip_protocol="ipv4", using_http_streamer=False, using_c_fluent_streamer=False):
+def verify_streaming_with_conf(base_test:BaseTestTfs, ip_protocol="ipv4", \
+                               using_http_streamer=False, using_c_fluent_streamer=False) -> Tuple[bool, str]:
     """
     Verify streaming with http protocol, or with forward python/c protocol using {ip_protocol}
     """

--- a/plugins/fluentd_telemetry_plugin/tests/protocol_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/protocol_test.py
@@ -1,0 +1,77 @@
+import pytest
+import time
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    # remove the attributes file for a clear attribute test
+    base_test.run_simulation()
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    # remove it once again so it will not mess up other tests
+
+def protocol_ipv4_test(setup_conf):
+    """
+    Test all the options using protocol ipv4
+    Forward and Http protocol, includes c fluent streamer and python steamer
+    """
+
+    # testing protocol Forward
+    # testing python fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf,"ipv4",False,False)
+    assert result, message
+
+    # testing C fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf,"ipv4",False,True)
+    assert result, message
+
+    # Testing HTTP protocol
+    # testing python fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf,"ipv4",True,True)
+    assert result, message
+
+def protocol_ipv6_test(setup_conf):
+    """
+    Test all options using ipv6
+    """
+    # testing protocol Forward
+    # testing python fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf,"ipv6",False,False)
+    assert result, message
+
+    # testing C fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf,"ipv6",False,True)
+    assert result, message
+
+    # Testing HTTP protocol
+    # testing python fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf,"ipv6",True,True)
+    assert result, message
+
+def verify_streaming_with_conf(base_test:BaseTestTfs, ip_protocol="ipv4", using_http_streamer=False, using_c_fluent_streamer=False):
+    """
+    Verify streaming with http protocol, or with forward python/c protocol using {ip_protocol}
+    """
+    bind = ''
+    if ip_protocol == "ipv6":
+        bind = "::"
+    fluent_protocol = 'forward'
+    if using_http_streamer:
+        fluent_protocol = 'http'
+    print(f"verify stream with {fluent_protocol} protocol, on ip protocol {ip_protocol},"+
+          f" with using c fluent streamer {using_c_fluent_streamer}")
+    base_test.set_conf(c_fluent_streamer=using_c_fluent_streamer)
+    # Forward protocol using Python forward library
+    time.sleep(10)
+    base_test.prepare_fluentd(fluent_protocol, bind)
+    base_test.run_fluentd()
+    return base_test.verify_streaming(stream=True)

--- a/plugins/fluentd_telemetry_plugin/tests/stream_only_change.py
+++ b/plugins/fluentd_telemetry_plugin/tests/stream_only_change.py
@@ -1,0 +1,54 @@
+import pytest
+import time
+import pandas as pd
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    base_test.prepare_fluentd()
+    base_test.run_simulation(max_changing=1,interval=5.0)
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+
+def deep_check_test(setup_conf):
+    time.sleep(2)
+    # waiting for one message in the fluent
+    telemetry_url = setup_conf.get_simulation_url()[0]
+    telemetry_data = pd.read_csv(telemetry_url)
+
+    # convert to dataframe
+    plugin_data = setup_conf.extract_data_from_line(setup_conf.read_data())
+    plugin_df = pd.DataFrame(plugin_data)
+
+    # sort the dataframe so the rows will be in order
+    telemetry_data = telemetry_data.sort_values(by=['node_guid','port_num'])
+    plugin_df = plugin_df.sort_values(by=['node_guid','port_num'])
+
+    assert telemetry_data.equals(plugin_df), "deep_check show that dataframes are not equal"
+
+def get_new_data_test(setup_conf):
+    previous_data = setup_conf.read_data()
+    previous_df = pd.DataFrame(setup_conf.extract_data_from_line(previous_data))
+    previous_df = previous_df.sort_values(by=['node_guid','port_num'])
+    time.sleep(10)
+    now_data = setup_conf.read_data()
+    now_df = pd.DataFrame(setup_conf.extract_data_from_line(now_data))
+    now_df = now_df.sort_values(by=['node_guid','port_num'])
+
+    # checking that all is equal but the changing column
+    assert previous_df.iloc[:, 6:].equals(now_df.iloc[:, 6:]),\
+        "new data test: expected all the values but the changing column be the same, got difference."
+
+    # checking that the values on the changing columns did changed.
+    assert not (previous_df.iloc[:, 5] != now_df.iloc[:, 5]).all(),\
+        "new data test: expected a change on changing column, got all the values are equal between the changing."

--- a/plugins/fluentd_telemetry_plugin/tests/stream_only_change.py
+++ b/plugins/fluentd_telemetry_plugin/tests/stream_only_change.py
@@ -12,7 +12,7 @@ def setup_conf():
     """
     base_test = BaseTestTfs()
     base_test.prepare_fluentd()
-    base_test.run_simulation(max_changing=1,interval=5.0)
+    base_test.run_simulation(max_changing=1, interval=5.0)
     result = base_test.run_server()
     assert result > 0, "could not start the server"
     yield base_test
@@ -31,19 +31,19 @@ def deep_check_test(setup_conf):
     plugin_df = pd.DataFrame(plugin_data)
 
     # sort the dataframe so the rows will be in order
-    telemetry_data = telemetry_data.sort_values(by=['node_guid','port_num'])
-    plugin_df = plugin_df.sort_values(by=['node_guid','port_num'])
+    telemetry_data = telemetry_data.sort_values(by=['node_guid', 'port_num'])
+    plugin_df = plugin_df.sort_values(by=['node_guid', 'port_num'])
 
     assert telemetry_data.equals(plugin_df), "deep_check show that dataframes are not equal"
 
 def get_new_data_test(setup_conf):
     previous_data = setup_conf.read_data()
     previous_df = pd.DataFrame(setup_conf.extract_data_from_line(previous_data))
-    previous_df = previous_df.sort_values(by=['node_guid','port_num'])
+    previous_df = previous_df.sort_values(by=['node_guid', 'port_num'])
     time.sleep(10)
     now_data = setup_conf.read_data()
     now_df = pd.DataFrame(setup_conf.extract_data_from_line(now_data))
-    now_df = now_df.sort_values(by=['node_guid','port_num'])
+    now_df = now_df.sort_values(by=['node_guid', 'port_num'])
 
     # checking that all is equal but the changing column
     assert previous_df.iloc[:, 6:].equals(now_df.iloc[:, 6:]),\

--- a/plugins/fluentd_telemetry_plugin/tests/stream_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/stream_test.py
@@ -1,0 +1,61 @@
+import pytest
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    base_test.prepare_fluentd()
+    base_test.run_simulation()
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+
+def verify_bulk_test(setup_conf):
+    """Test bulk streaming
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf(bulk_streaming=True))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(bulk=True)
+    assert result, message
+
+def verify_non_bulk_test(setup_conf):
+    """Test not bulk streaming
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf(bulk_streaming=False))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(bulk=False)
+    assert result, message
+
+def verify_meta_test(setup_conf):
+    """Set meta information and test it
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf(meta=
+            {"alias_node_description": "node_namex",
+            "alias_node_guid": "GUID",
+            "add_type": "csv"}))
+    assert response_code == 200
+    result, message =  setup_conf.verify_streaming(meta="node_namex",constants="csv")
+    assert result, message
+
+def info_label_test(setup_conf):
+    """test the info label
+    """
+    result, message = setup_conf.verify_streaming(info_labels=True)
+    assert result, message
+
+def tag_msg_test(setup_conf):
+    """test the tag msg after changing it.
+    """
+    check_tag_msg = "pytest tag check"
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf(tag_name=check_tag_msg))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(tag_msg=check_tag_msg)
+    assert result, message

--- a/plugins/fluentd_telemetry_plugin/tests/telemetry_simulation.py
+++ b/plugins/fluentd_telemetry_plugin/tests/telemetry_simulation.py
@@ -1,0 +1,144 @@
+import time
+import http.server
+import random
+from datetime import datetime
+import io
+import csv
+import argparse
+from urllib.parse import urlparse
+import threading
+
+HEADER_DEFAULT = "generated_header"
+PORT_HEADERS_AMOUNT = 6
+PORT_HEADERS = ["timestamp",'source_id', 'tag', 'node_guid', 'port_guid', 'port_num']
+
+class TelemetryData:
+    def __init__(self, rows:int, columns:int, max_changes:int=None, path:str="", update_interval:float=1.0):
+        self.rows = rows
+        self.columns = columns
+        self.update_interval = update_interval
+        self.generate_headers(columns)
+        if max_changes:
+            self.max_changes = max_changes
+        else:
+            self.max_changes = len(columns)
+        self.path = path
+        self.data = [[random.randint(0,100) for _ in range(columns)] for _ in range(rows)]
+        self.generate_ports(rows)
+        self.last_update = datetime.now()
+        self.running = False
+
+    def update_date(self):
+        current_time = datetime.now()
+        current_timestamp = int(current_time.timestamp())
+        if (current_time - self.last_update).total_seconds() > 1:
+            for row in range(self.rows):
+                self.data[row][0] = current_timestamp
+                for col in range(self.columns):
+                    if col >= self.max_changes:
+                        break
+                    self.data[row][col + PORT_HEADERS_AMOUNT] = random.randint(0,100)
+            self.last_update = current_time
+
+    def run_updates(self):
+        if self.running:
+            return # already running somewhere else
+        self.running = True
+        while self.running:
+            self.update_date()
+            time.sleep(self.update_interval)
+
+    def stop_updates(self):
+        self.running = False
+
+    def generate_headers(self,num_of_columns:int):
+        headers = [] + PORT_HEADERS
+        random_index = random.randint(0,num_of_columns)
+        for index in range(num_of_columns):
+            headers.append(HEADER_DEFAULT + "_" + str(random_index + index * num_of_columns))
+        self.headers = headers
+    
+    def generate_ports(self, rows_num: int):
+        ports = []
+        for row_index in range(rows_num):
+            port_str = f'0x{random.randrange(16**16):016x}'
+            # holds the prefix of each simulated csv rows , list of counters structures(will be filled further)
+            self.data[row_index] = ["",port_str,"",port_str,port_str,"1"] + self.data[row_index]
+        return ports
+    
+    def generate_csv(self):
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(self.headers)
+        writer.writerows(self.data)
+        return output.getvalue()
+
+
+class TelemetryRequestHandler(http.server.SimpleHTTPRequestHandler):
+
+    telemetry_paths = {}
+
+    def do_GET(self):
+        parsed_path = urlparse(self.path)
+        if parsed_path.path in self.telemetry_paths:
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            telemetry_data = self.telemetry_paths[parsed_path.path]
+            self.wfile.write(telemetry_data.generate_csv().encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+        
+    
+class TelemetryServer:
+    def __init__(self, server_address:tuple, telemetry_path:list, rows:int, columns:int, max_changes:int, interval:float):
+        self.server_address = server_address
+        self.telemetry_data = {}
+        for path in telemetry_path:
+            self.telemetry_data[path] = TelemetryData(rows, columns, max_changes, path, interval)
+        self.httpd = None
+        self.update_thread = {}
+    
+    def start(self):
+        print(f"Starting serving telemetry on port {self.server_address[1]}")
+        for path,telemetry_data in self.telemetry_data.items():
+            self.update_thread[path] = threading.Thread(target=telemetry_data.run_updates, daemon=True)
+            self.update_thread[path].start()
+            print(f"Serving at http://127.0.0.1:{self.server_address[1]}{path}")
+
+        TelemetryRequestHandler.telemetry_paths = self.telemetry_data
+
+        self.httpd = http.server.HTTPServer(self.server_address, TelemetryRequestHandler)
+        self.httpd.serve_forever()
+
+    def stop(self):
+        if self.update_thread:
+            for path, telemetry in self.telemetry_data.items():
+                telemetry.stop_updates()
+                self.update_thread[path].join()
+            if self.httpd:
+                self.httpd.shutdown()
+                self.httpd.server_close()
+
+def main():
+    parser = argparse.ArgumentParser(description="Telemetry Server")
+    parser.add_argument('--rows', type=int, default=10, help='')
+    parser.add_argument('--columns', type=int, default=5, help='')
+    parser.add_argument('--update_interval', type=float, default=1.0, help='')
+    parser.add_argument('--max_changing', type=int, default=10, help='')
+    parser.add_argument('--port', type=int, default=9007, help='')
+    parser.add_argument('--paths', nargs='+', default=["/csv/xcset/ib_basic_debug"], help='')
+
+    args = parser.parse_args()
+    server_address = ('', args.port)
+
+    server = TelemetryServer(server_address, args.paths, args.rows, args.columns, args.max_changing, args.update_interval)
+    try:
+        server.start()
+    except (KeyboardInterrupt,SystemExit):
+        print("shutting down the server")
+        server.stop()
+
+if __name__ == "__main__":
+    main()

--- a/plugins/fluentd_telemetry_plugin/tests/telemetry_simulation.py
+++ b/plugins/fluentd_telemetry_plugin/tests/telemetry_simulation.py
@@ -20,7 +20,7 @@ class TelemetryData:
         self.generate_headers(columns)
         if max_changes:
             self.max_changes = max_changes
-        else:
+        elif max_changes == 0 or max_changes is None:
             self.max_changes = len(columns)
         self.path = path
         self.data = [[random.randint(0,100) for _ in range(columns)] for _ in range(rows)]

--- a/plugins/fluentd_telemetry_plugin/tests/telemetry_simulation.py
+++ b/plugins/fluentd_telemetry_plugin/tests/telemetry_simulation.py
@@ -51,9 +51,9 @@ class TelemetryData:
     def stop_updates(self):
         self.running = False
 
-    def generate_headers(self,num_of_columns:int):
+    def generate_headers(self, num_of_columns:int):
         headers = [] + PORT_HEADERS
-        random_index = random.randint(0,num_of_columns)
+        random_index = random.randint(0, num_of_columns)
         for index in range(num_of_columns):
             headers.append(HEADER_DEFAULT + "_" + str(random_index + index * num_of_columns))
         self.headers = headers
@@ -63,7 +63,7 @@ class TelemetryData:
         for row_index in range(rows_num):
             port_str = f'0x{random.randrange(16**16):016x}'
             # holds the prefix of each simulated csv rows , list of counters structures(will be filled further)
-            self.data[row_index] = ["",port_str,"",port_str,port_str,"1"] + self.data[row_index]
+            self.data[row_index] = ["", port_str, "", port_str, port_str, "1"] + self.data[row_index]
         return ports
     
     def generate_csv(self):
@@ -89,8 +89,7 @@ class TelemetryRequestHandler(http.server.SimpleHTTPRequestHandler):
         else:
             self.send_response(404)
             self.end_headers()
-        
-    
+
 class TelemetryServer:
     def __init__(self, server_address:tuple, telemetry_path:list, rows:int, columns:int, max_changes:int, interval:float):
         self.server_address = server_address
@@ -102,7 +101,7 @@ class TelemetryServer:
     
     def start(self):
         print(f"Starting serving telemetry on port {self.server_address[1]}")
-        for path,telemetry_data in self.telemetry_data.items():
+        for path, telemetry_data in self.telemetry_data.items():
             self.update_thread[path] = threading.Thread(target=telemetry_data.run_updates, daemon=True)
             self.update_thread[path].start()
             print(f"Serving at http://127.0.0.1:{self.server_address[1]}{path}")

--- a/plugins/fluentd_telemetry_plugin/tests/telemetry_simulation.py
+++ b/plugins/fluentd_telemetry_plugin/tests/telemetry_simulation.py
@@ -128,7 +128,7 @@ def main():
     parser.add_argument('--update_interval', type=float, default=1.0, help='')
     parser.add_argument('--max_changing', type=int, default=10, help='')
     parser.add_argument('--port', type=int, default=9007, help='')
-    parser.add_argument('--paths', nargs='+', default=["/csv/xcset/ib_basic_debug"], help='')
+    parser.add_argument('--paths', nargs='+', default=["/csv/metrics"], help='')
 
     args = parser.parse_args()
     server_address = ('', args.port)


### PR DESCRIPTION
## What
Add Pytests to the TFS plugin and a simulation of telemetry for that as well.
Using the test plan of TFS. For example:
* Set configuration and attributes using RestApi requests.
* Verify the stream using all protocols and streamers.
* Verify meta, tag-name, info labels, and the structure of the message.
* Verify bulk and no bulk streaming,
* Verify stream-only new samples.

## Why ?
[Task](https://redmine.mellanox.com/issues/4288713)
Add Pytest tests for git runner on each the TFS commit.

## How ?
Added Base functions using general utils from sdk_tool. All the other pytest uses those base functions to create a setup and activate common functions. All the tests will be added to this PR as well.

## Testing ?
This is the test for the plugin.

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
