### PR TITLE
Remove the "container" string from the compressed file name

### DIFF
--- a/plugins/fluentd_telemetry_plugin/build/docker_build.sh
+++ b/plugins/fluentd_telemetry_plugin/build/docker_build.sh
@@ -84,8 +84,8 @@ function build_docker_image()
     docker images | grep ${image_with_prefix}
     printf "\n\n\n"
 
-    echo "docker save ${image_with_prefix_and_version} | gzip > ${out_dir}/${full_image_version}-container.tgz"
-    docker save ${image_with_prefix_and_version} | gzip > ${out_dir}/${full_image_version}-container.tgz
+    echo "docker save ${image_with_prefix_and_version} | gzip > ${out_dir}/${full_image_version}.tgz"
+    docker save ${image_with_prefix_and_version} | gzip > ${out_dir}/${full_image_version}.tgz
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
         echo "Failed to save image"


### PR DESCRIPTION
## What
Remove the "container" string from the compressed file name

## Why ?
To comply with the new naming convention.
## How ?
Update the docker_build.sh script

## Testing ?
manualy

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
