### PR TITLE
issue:4404931 Convert prints to logger

### DIFF
--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/utils/netfix/link_flapping.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/utils/netfix/link_flapping.py
@@ -298,5 +298,5 @@ def get_link_flapping(prev_counters_csv, cur_counters_csv):
         )
         return linkdown_df1
     except Exception as e:
-        log.LOGGER.debug(f"Error getting link flapping: {e}")
+        log.LOGGER.debug("Error getting link flapping: %s", str(e))
         return pd.DataFrame()

--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/utils/netfix/link_flapping.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/utils/netfix/link_flapping.py
@@ -14,9 +14,8 @@ This is the main logic for identifying flapping links
 """
 
 from datetime import datetime
-import traceback
 import warnings
-
+import loganalyze.logger as log
 import pandas as pd
 from loganalyze.utils.netfix.netfix_utils import (
     read_and_preprocessing_file,
@@ -299,6 +298,5 @@ def get_link_flapping(prev_counters_csv, cur_counters_csv):
         )
         return linkdown_df1
     except Exception as e:
-        print(e)
-        traceback.print_exc()
+        log.LOGGER.debug(f"Error getting link flapping: {e}")
         return pd.DataFrame()

--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/utils/netfix/netfix_utils/__init__.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/utils/netfix/netfix_utils/__init__.py
@@ -130,7 +130,7 @@ def read_and_preprocessing_file(file_path: str):
     df_file = pd.read_csv(file_path, encoding="ISO-8859-1")
 
     if df_file.shape[0] == 0:
-        log.LOGGER.debug(" ERROR: empty file - %s", file_path)
+        log.LOGGER.debug("ERROR reading the file %s as it is empty", file_path)
 
     df_file = df_file.rename(columns={"Node_Description": "node_description"})
 
@@ -189,7 +189,7 @@ def read_and_preprocessing_file(file_path: str):
     ]
     for col in must_columns_in_files:
         if col not in df_file.columns:
-            log.LOGGER.debug("%s is missing in data !!!", col)
+            log.LOGGER.debug("Error as column %s is missing in data !!!", col)
 
     df_file = df_file[df_file.Port_Number != 65]
 
@@ -227,7 +227,7 @@ def read_and_preprocessing_file(file_path: str):
             df_file[col] = pd.to_numeric(df_file[col], errors="coerce")
             df_file.dropna(subset=[col], inplace=True)
         else:
-            log.LOGGER.debug("%s not exists in dataframe", col)
+            log.LOGGER.debug("Error as column %s not exists in dataframe", col)
 
     # add to df min /max/std of time since lase clear per switch/host name + add 'server_name' col
     df_file = get_time_since_last_clear_per_groups(df_file)
@@ -264,7 +264,7 @@ def get_time_since_last_clear_per_groups(df):
         mask = df.Device_ID.astype(str).str.contains("Connect")
 
     if not "Time_since_last_clear" in df.columns:
-        log.LOGGER.debug(" Time_since_last_clear not exists in df ")
+        log.LOGGER.debug("Error as Time_since_last_clear not exists in df")
         return df
 
     df.loc[mask, "server_name"] = df.loc[mask, "node_description"].apply(

--- a/plugins/ufm_log_analyzer_plugin/src/loganalyze/utils/netfix/netfix_utils/__init__.py
+++ b/plugins/ufm_log_analyzer_plugin/src/loganalyze/utils/netfix/netfix_utils/__init__.py
@@ -16,7 +16,7 @@ This module provides utility functions for the netfix_utils package.
 import pandas as pd
 from pandas.api.types import is_string_dtype
 from pandas.api.types import is_numeric_dtype
-
+import loganalyze.logger as log
 
 Phy_Manager_State_dict_str = {
     "Active_or_Linkup": "Active",
@@ -130,7 +130,7 @@ def read_and_preprocessing_file(file_path: str):
     df_file = pd.read_csv(file_path, encoding="ISO-8859-1")
 
     if df_file.shape[0] == 0:
-        print(" ERROR: empty file - ", file_path)
+        log.LOGGER.debug(" ERROR: empty file - %s", file_path)
 
     df_file = df_file.rename(columns={"Node_Description": "node_description"})
 
@@ -189,7 +189,7 @@ def read_and_preprocessing_file(file_path: str):
     ]
     for col in must_columns_in_files:
         if col not in df_file.columns:
-            print(col, " is missing in data !!!")
+            log.LOGGER.debug("%s is missing in data !!!", col)
 
     df_file = df_file[df_file.Port_Number != 65]
 
@@ -227,7 +227,7 @@ def read_and_preprocessing_file(file_path: str):
             df_file[col] = pd.to_numeric(df_file[col], errors="coerce")
             df_file.dropna(subset=[col], inplace=True)
         else:
-            print(col, " not exists in dataframe")
+            log.LOGGER.debug("%s not exists in dataframe", col)
 
     # add to df min /max/std of time since lase clear per switch/host name + add 'server_name' col
     df_file = get_time_since_last_clear_per_groups(df_file)
@@ -264,7 +264,7 @@ def get_time_since_last_clear_per_groups(df):
         mask = df.Device_ID.astype(str).str.contains("Connect")
 
     if not "Time_since_last_clear" in df.columns:
-        print(" Time_since_last_clear not exists in df ")
+        log.LOGGER.debug(" Time_since_last_clear not exists in df ")
         return df
 
     df.loc[mask, "server_name"] = df.loc[mask, "node_description"].apply(


### PR DESCRIPTION
## What
In the link flapping logic, since it was a general util, we had prints.
Now that we moved it to be under the log analyzer, we can use the logger and not always prints the issues
(As a reminder, this tool hides all the issues it has, unless the user asks for the log level to be debug)

## Testing ?
Run the tool after the change and the errors are gone.
## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
