### PR TITLE
Issue 4414258: TFS Add no preserve arguments to init.sh

### DIFF
--- a/plugins/fluentd_telemetry_plugin/scripts/init.sh
+++ b/plugins/fluentd_telemetry_plugin/scripts/init.sh
@@ -34,7 +34,7 @@ if [[ "${READ_ONLY_FS}" == "true" ]]; then
     do
         echo "$vol" >> "$SHARED_VOLUMES_PATH"
     done
-    CP_ARGS="${CP_ARGS} --no-preserve=mode"
+    CP_ARGS="${CP_ARGS} --no-preserve=all"
 fi 
 
 # Copy configuration files to the config folder

--- a/plugins/fluentd_telemetry_plugin/scripts/init.sh
+++ b/plugins/fluentd_telemetry_plugin/scripts/init.sh
@@ -25,10 +25,7 @@ readonly SHARED_VOLUMES_PATH="${CONFIG_PATH}/${PLUGIN_NAME}_shared_volumes.conf"
 # Create the config folder
 mkdir -p "$CONFIG_PATH"
 
-# Copy configuration files to the config folder
-cp "$TFS_PLUGIN_DIR"/*.conf $CONFIG_PATH
-cp "$TFS_PLUGIN_DIR"/fluentd_telemetry_plugin.cfg $CONFIG_PATH
-
+CP_ARGS="-a"
 # If the file system is read-only non root
 if [[ "${READ_ONLY_FS}" == "true" ]]; then
     # Generate the shared volumes configuration
@@ -37,6 +34,11 @@ if [[ "${READ_ONLY_FS}" == "true" ]]; then
     do
         echo "$vol" >> "$SHARED_VOLUMES_PATH"
     done
+    CP_ARGS="${CP_ARGS} --no-preserve=mode"
 fi 
+
+# Copy configuration files to the config folder
+cp $CP_ARGS "$TFS_PLUGIN_DIR"/*.conf $CONFIG_PATH
+cp $CP_ARGS "$TFS_PLUGIN_DIR"/fluentd_telemetry_plugin.cfg $CONFIG_PATH
 
 exit 0


### PR DESCRIPTION
## What
Fixes a SELinux bug in init.sh.

## Why ?
SELinux cp does not work without the no-preserve argument.

## How ?
Adds the --no-perveserve=all to the cp command in the init.sh

## Testing ?
Manual Testing.

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
