### PR TITLE
issue: #4372023: [TFS Plugin] After using the REST API, a plugin refresh is required (Previously, it was not needed)

### DIFF
--- a/plugins/fluentd_telemetry_plugin/src/streaming_config_parser.py
+++ b/plugins/fluentd_telemetry_plugin/src/streaming_config_parser.py
@@ -2,8 +2,9 @@ import logging
 
 # pylint: disable=no-name-in-module,import-error
 from utils.config_parser import ConfigParser
+from ufm_sdk_tools.src.utils.singleton import SingletonMeta
 
-class UFMTelemetryStreamingConfigParser(ConfigParser):
+class UFMTelemetryStreamingConfigParser(ConfigParser, metaclass=SingletonMeta):
     """
     UFMTelemetryStreamingConfigParser class to manage
     the TFS configurations


### PR DESCRIPTION
## What
fluentd-endpoint.host did not exist in the streaming TFS while it existed in the API web client.

## Why ?
[P3](https://redmine.mellanox.com/issues/4372023)
There were two configuration parsers running in the TFS container. The API web client config parser and the streaming TFS config parser were not the same. 

## How ?
Added Singleton pattern to UFMTelemetryStreamingConfigParser by implementing the SingletonMeta metaclass from ufm_sdk_tools.src.utils.singleton. The singleton metaclass prevents duplication of the class.

## Testing ?
Manual testing with Anan.

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
