### PR TITLE
issue:4462374 [CI] Add Anan to auth users to upload to dockerhub

### DIFF
--- a/.ci/jenkinsfile_hub_uploader.groovy
+++ b/.ci/jenkinsfile_hub_uploader.groovy
@@ -18,7 +18,7 @@ pipeline{
                 script {
                     withCredentials([usernamePassword(credentialsId: '0fbf63c0-4a61-4543-811d-a182df47711b', usernameVariable: 'DH_USER', passwordVariable: 'DH_TOKEN' )]){
                         wrap([$class: 'BuildUser']) {
-                            def authorized_users = ["bitkin", "afok", "kobib", "drorl", "tlerner", "omarj", "samerd", "atolikin", "atabachnik", "eylonk", "lennyv", "asafb", "sspormas", "mkianovsky", "asafb", "samerd"]
+                            def authorized_users = ["bitkin", "afok", "kobib", "drorl", "tlerner", "omarj", "samerd", "atolikin", "atabachnik", "eylonk", "lennyv", "asafb", "sspormas", "mkianovsky", "asafb", "samerd", "anana"]
                             def BUILD_USER_ID = env.BUILD_USER_ID.tokenize("@")[0]
                             if (!authorized_users.contains(BUILD_USER_ID)) {
                                 error """${BUILD_USER_ID} is not authorized to upload images to Docker Hub.


### PR DESCRIPTION
## What
Added Anan  to upload to dockerhub 

## Why ?
needed https://github.com/Mellanox/ufm_sdk_3.0/pull/329

## How ?
added to auth users

## Testing ?
_How was this feature tested? Did you add unit tests? Did you add E2E tests?_

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
