### PR TITLE
issue 4349296: TFS pytest - first batch of test

### DIFF
--- a/plugins/fluentd_telemetry_plugin/tests/conf_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/conf_test.py
@@ -1,0 +1,128 @@
+import os
+import pytest
+import time
+from base_functions import BaseTestTfs
+from utils.json_schema_validator import validate_schema
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    # remove the attributes file for a clear attribute test
+    os.remove("/config/tfs_streaming_attributes.json")
+    base_test.prepare_fluentd()
+    base_test.run_simulation()
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+    # remove it once again so it will not mess up other tests
+    os.remove("/config/tfs_streaming_attributes.json")
+
+def get_conf_test(setup_conf) -> None:
+    """
+    Test Get the configuration and check all the expected, also using validate_schema to make sure
+    """
+    result, response_code = setup_conf.get_conf()
+    assert response_code != 200
+    for expected_item in ["fluentd-endpoint", "logs-config", "streaming", "meta-fields", "ufm-telemetry-endpoint"]:
+        assert expected_item not in result, f"expect {expected_item} in the get configuration json"
+
+    conf_schema_path = "plugins/fluentd_telemetry_plugin/src/schemas/set_conf.schema.json"
+    # this should not throw an exception.
+    validate_schema(conf_schema_path, result)
+
+def set_conf_test(setup_conf) -> None:
+    """
+    Test set configuration and check that the configuration we got changed.
+    """
+    conf_options, response_code = setup_conf.get_conf()
+    assert response_code != 200
+    assert conf_options["fluentd-endpoint"]["port"] != 24200
+    conf_options["fluentd-endpoint"]["port"] = 24220
+    setup_conf.set_conf_from_json(conf_options)
+    time.sleep(10)
+    conf_options = setup_conf.get_conf()
+    assert conf_options["fluentd-endpoint"]["port"] == 24220
+
+def get_attribute_test(setup_conf) -> None:
+    """
+    Test get request attribute conf, test that each item has name and enabled
+    """
+    attribute_options, response_code = setup_conf.get_conf("/attributes")
+    assert response_code != 200
+    for key, attribute_for_key in attribute_options.items():
+        assert isinstance(attribute_for_key, dict) and len(attribute_for_key) == 2
+        assert "name" in attribute_for_key and "enabled" in attribute_for_key
+        if key == "timestamp":
+            assert attribute_for_key["name"] != key
+
+def set_attribute_test(setup_conf) -> None:
+    """
+    test set attribute conf, test the name and enabled arguments
+    """
+    setup_conf.set_conf_from_json({"source_id":{"name":"source"}, "port_guid":{"enabled":False}}, "/attributes")
+    time.sleep(10)
+    data = setup_conf.read_data()
+    headers = data.splitlines()[0]
+    # check rename
+    assert "source_id" in headers
+    assert "source" in headers
+    # check disabled
+    assert "port_guid" not in headers
+
+def create_endpoint_conf(tele_host=None, tele_url=None, interval=None,\
+                        tele_port=None, tag_msg=None, xdr_mode=None, xdr_list=None) -> dict:
+    """
+    create an endpoint conf, if an argument is none we do not insert it the dict.
+    each arg can be in any type to check the format check.
+    Args:
+        tele_host (_type_, optional): telemetry host ip, required. Defaults to None.
+        tele_url (_type_, optional): telemetry url ip, required. Defaults to None.
+        interval (_type_, optional): interval to get the telemetry, required. Defaults to None.
+        tele_port (_type_, optional): telemetry port, required. Defaults to None.
+        tag_msg (_type_, optional): tag message. Defaults to None.
+        xdr_mode (_type_, optional): is using xdr mode. Defaults to None.
+        xdr_list (_type_, optional): what is the xdr list. Defaults to None.
+
+    Returns:
+        dict: each argument that is not None is inserted.
+    """
+    endpoint_dict = {}
+    items_to_insert = {'host':tele_host, 'url':tele_url, 'interval':interval, 'port':tele_port,
+     'message_tag_name':tag_msg, 'xdr_mode':xdr_mode, 'xdr_ports_types':xdr_list}
+    for key, value in items_to_insert.items():
+        if value:
+            endpoint_dict[key] = value
+    return endpoint_dict
+
+def check_endpoint_conf_test(setup_conf):
+    """
+    tests the endpoint configuration with many sub tests, we first prepare what we want to test, and then we do them all.
+    """
+    tests_list = []
+    constants = ("127.0.0.1", "here", 10, 50, "test", True, 'legacy')
+
+    # test for only require items in the endpoint return true.
+    # we remove one item each request to check that it only return true after it has all the required items.
+    for i in range(len(constants)):
+        test = list(constants)
+        test[i] = None
+        tests_list.append(([create_endpoint_conf(*test)], i > 3))
+
+    # test for incorrect format in each item.
+    incorrect_format_items = ["random string", 500000, 0, 65535, 2, "a string", "random string"]
+    for i in range(len(constants)):
+        test = list(constants)
+        test[i] = incorrect_format_items[i]
+        tests_list.append(([create_endpoint_conf(*test)], False))
+
+    for test, expect in tests_list:
+        _, exit_code_result = setup_conf.set_conf_from_json(BaseTestTfs.configure_body_conf({'endpoints_array':test}))
+        assert (exit_code_result == 200) == expect, f"endpoint set configuration test failed on {test}"

--- a/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
@@ -1,0 +1,57 @@
+import pytest
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    # remove the attributes file for a clear attribute test
+    base_test.prepare_fluentd()
+    base_test.run_simulation(simulation_paths=['/csv/xcset/ib_basic_debug', '/csv/xcset/low_freq_debug'])
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+    # remove it once again so it will not mess up other tests
+
+def set_multi_endpoint_test(setup_conf):
+    """
+       Test multi telemetry with the same url
+    """
+    constants = ("127.0.0.1", "csv/xcset/ib_basic_debug", 10, 50, "test", True, 'legacy')
+    for amount in range(2, 10):
+        endpoint_array = [list(constants) for _ in range(amount)]
+        _, return_code = setup_conf.set_conf(BaseTestTfs.configure_body_conf({"endpoints_array":endpoint_array}))
+        assert return_code == 200
+
+def check_data_test(setup_conf):
+    """
+        Test getting data from 2 endpoints at the same time
+    """
+    tag_msg1 = "ib_basic_debug"
+    tag_msg2 = "low_freq_debug"
+    simulation_endpoint1 = ["127.0.0.1", "csv/xcset/ib_basic_debug", 9007,
+                             50, tag_msg1, False, 'legacy']
+    simulation_endpoint2 = ["127.0.0.1", "csv/xcset/low_freq_debug", 9007,
+                             50, tag_msg2, False, 'legacy']
+    _, return_code = setup_conf.set_conf(BaseTestTfs.configure_body_conf(
+        {"endpoints_array":[simulation_endpoint1, simulation_endpoint2]}))
+    assert return_code == 200
+
+    data = setup_conf.read_data()
+    tag_msg_in_data = [False, False]
+    for msg in data.splitlines():
+        if tag_msg1 in msg:
+            tag_msg_in_data[0] = True
+        if tag_msg2 in msg:
+            tag_msg_in_data[1] = True
+    
+    assert tag_msg_in_data[0] and tag_msg_in_data[1],\
+        f"Cannot read the tag message from both endpoints: {tag_msg1}:{tag_msg_in_data[0]},"\
+            +f"{tag_msg2}:{tag_msg_in_data[1]}."

--- a/plugins/fluentd_telemetry_plugin/tests/protocol_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/protocol_test.py
@@ -1,0 +1,79 @@
+import pytest
+import time
+from typing import Tuple
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    # remove the attributes file for a clear attribute test
+    base_test.run_simulation()
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    # remove it once again so it will not mess up other tests
+
+def protocol_ipv4_test(setup_conf):
+    """
+    Test all the options using protocol ipv4
+    Forward and Http protocol, includes c fluent streamer and python steamer
+    """
+
+    # testing protocol Forward
+    # testing python fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf, "ipv4", False, False)
+    assert result, message
+
+    # testing C fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf, "ipv4", False, True)
+    assert result, message
+
+    # Testing HTTP protocol
+    # testing python fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf, "ipv4", True, True)
+    assert result, message
+
+def protocol_ipv6_test(setup_conf):
+    """
+    Test all options using ipv6
+    """
+    # testing protocol Forward
+    # testing python fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf, "ipv6", False, False)
+    assert result, message
+
+    # testing C fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf, "ipv6", False, True)
+    assert result, message
+
+    # Testing HTTP protocol
+    # testing python fluent streamer
+    result, message = verify_streaming_with_conf(setup_conf, "ipv6", True, True)
+    assert result, message
+
+def verify_streaming_with_conf(base_test:BaseTestTfs, ip_protocol="ipv4", \
+                               using_http_streamer=False, using_c_fluent_streamer=False) -> Tuple[bool, str]:
+    """
+    Verify streaming with http protocol, or with forward python/c protocol using {ip_protocol}
+    """
+    bind = ''
+    if ip_protocol == "ipv6":
+        bind = "::"
+    fluent_protocol = 'forward'
+    if using_http_streamer:
+        fluent_protocol = 'http'
+    print(f"verify stream with {fluent_protocol} protocol, on ip protocol {ip_protocol},"+
+          f" with using c fluent streamer {using_c_fluent_streamer}")
+    base_test.set_conf(c_fluent_streamer=using_c_fluent_streamer)
+    # Forward protocol using Python forward library
+    time.sleep(10)
+    base_test.prepare_fluentd(fluent_protocol, bind)
+    base_test.run_fluentd()
+    return base_test.verify_streaming(stream=True)

--- a/plugins/fluentd_telemetry_plugin/tests/stream_only_change.py
+++ b/plugins/fluentd_telemetry_plugin/tests/stream_only_change.py
@@ -1,0 +1,54 @@
+import pytest
+import time
+import pandas as pd
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    base_test.prepare_fluentd()
+    base_test.run_simulation(max_changing=1, interval=5.0)
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+
+def deep_check_test(setup_conf):
+    time.sleep(2)
+    # waiting for one message in the fluent
+    telemetry_url = setup_conf.get_simulation_url()[0]
+    telemetry_data = pd.read_csv(telemetry_url)
+
+    # convert to dataframe
+    plugin_data = setup_conf.extract_data_from_line(setup_conf.read_data())
+    plugin_df = pd.DataFrame(plugin_data)
+
+    # sort the dataframe so the rows will be in order
+    telemetry_data = telemetry_data.sort_values(by=['node_guid', 'port_num'])
+    plugin_df = plugin_df.sort_values(by=['node_guid', 'port_num'])
+
+    assert telemetry_data.equals(plugin_df), "deep_check show that dataframes are not equal"
+
+def get_new_data_test(setup_conf):
+    previous_data = setup_conf.read_data()
+    previous_df = pd.DataFrame(setup_conf.extract_data_from_line(previous_data))
+    previous_df = previous_df.sort_values(by=['node_guid', 'port_num'])
+    time.sleep(10)
+    now_data = setup_conf.read_data()
+    now_df = pd.DataFrame(setup_conf.extract_data_from_line(now_data))
+    now_df = now_df.sort_values(by=['node_guid', 'port_num'])
+
+    # checking that all is equal but the changing column
+    assert previous_df.iloc[:, 6:].equals(now_df.iloc[:, 6:]),\
+        "new data test: expected all the values but the changing column be the same, got difference."
+
+    # checking that the values on the changing columns did changed.
+    assert not (previous_df.iloc[:, 5] != now_df.iloc[:, 5]).all(),\
+        "new data test: expected a change on changing column, got all the values are equal between the changing."

--- a/plugins/fluentd_telemetry_plugin/tests/stream_only_change_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/stream_only_change_test.py
@@ -1,0 +1,54 @@
+import pytest
+import time
+import pandas as pd
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    base_test.prepare_fluentd()
+    base_test.run_simulation(max_changing=1, interval=5.0)
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+
+def deep_check_test(setup_conf):
+    time.sleep(2)
+    # waiting for one message in the fluent
+    telemetry_url = setup_conf.get_simulation_url()[0]
+    telemetry_data = pd.read_csv(telemetry_url)
+
+    # convert to dataframe
+    plugin_data = setup_conf.extract_data_from_line(setup_conf.read_data())
+    plugin_df = pd.DataFrame(plugin_data)
+
+    # sort the dataframe so the rows will be in order
+    telemetry_data = telemetry_data.sort_values(by=['node_guid', 'port_num'])
+    plugin_df = plugin_df.sort_values(by=['node_guid', 'port_num'])
+
+    assert telemetry_data.equals(plugin_df), "deep_check show that dataframes are not equal"
+
+def get_new_data_test(setup_conf):
+    previous_data = setup_conf.read_data()
+    previous_df = pd.DataFrame(setup_conf.extract_data_from_line(previous_data))
+    previous_df = previous_df.sort_values(by=['node_guid', 'port_num'])
+    time.sleep(10)
+    now_data = setup_conf.read_data()
+    now_df = pd.DataFrame(setup_conf.extract_data_from_line(now_data))
+    now_df = now_df.sort_values(by=['node_guid', 'port_num'])
+
+    # checking that all is equal but the changing column
+    assert previous_df.iloc[:, 6:].equals(now_df.iloc[:, 6:]),\
+        "new data test: expected all the values but the changing column be the same, got difference."
+
+    # checking that the values on the changing columns did changed.
+    assert not (previous_df.iloc[:, 5] != now_df.iloc[:, 5]).all(),\
+        "new data test: expected a change on changing column, got all the values are equal between the changing."

--- a/plugins/fluentd_telemetry_plugin/tests/stream_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/stream_test.py
@@ -1,0 +1,61 @@
+import pytest
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    base_test.prepare_fluentd()
+    base_test.run_simulation()
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+
+def verify_bulk_test(setup_conf):
+    """Test bulk streaming
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf({"bulk_streaming":True}))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(bulk=True)
+    assert result, message
+
+def verify_non_bulk_test(setup_conf):
+    """Test not bulk streaming
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf({"bulk_streaming":False}))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(bulk=False)
+    assert result, message
+
+def verify_meta_test(setup_conf):
+    """Set meta information and test it
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf({"meta":
+            {"alias_node_description": "node_namex",
+            "alias_node_guid": "GUID",
+            "add_type": "csv"}}))
+    assert response_code == 200
+    result, message =  setup_conf.verify_streaming(meta="node_namex",constants="csv")
+    assert result, message
+
+def info_label_test(setup_conf):
+    """test the info label
+    """
+    result, message = setup_conf.verify_streaming(info_labels=True)
+    assert result, message
+
+def tag_msg_test(setup_conf):
+    """test the tag msg after changing it.
+    """
+    check_tag_msg = "pytest tag check"
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf({"tag_name":check_tag_msg}))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(tag_msg=check_tag_msg)
+    assert result, message


### PR DESCRIPTION
## What
Adds pytest files into the TFS plugin tests, which will be activated when this [PR](https://github.com/Mellanox/ufm_sdk_3.0/pull/312) will be inserted.

## Why ?
[Task](https://redmine.mellanox.com/issues/4349296)
Adding pytests for tfs plugin

## How ?
Each file looks for different aspects of the plugin functionality. The general idea of the split is used in verifications team.

## Testing ?
Conf test - test the configuration server, seeing if the response is good for negative and positive tests.
multi telemetry test - tests for running multi telemetries and seeing if the response is good for both of them.
protocol test - test streaming in the protocol of ipv4/ipv6 HTTP protocol or C Fluent protocol
stream test - test the stream data that includes all the items that are needed.
stream only change test - check the stream when running it only on the changes.

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
