### PR TITLE
issue 4349296: TFS pytest - Add core pytest test files for telemetry streaming part 2

### DIFF
--- a/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/multi_endpoints_test.py
@@ -1,0 +1,57 @@
+import pytest
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    # remove the attributes file for a clear attribute test
+    base_test.prepare_fluentd()
+    base_test.run_simulation(simulation_paths=['/csv/xcset/ib_basic_debug', '/csv/xcset/low_freq_debug'])
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+    # remove it once again so it will not mess up other tests
+
+def set_multi_endpoint_test(setup_conf):
+    """
+       Test multi telemetry with the same url
+    """
+    constants = ("127.0.0.1", "csv/xcset/ib_basic_debug", 10, 50, "test", True, 'legacy')
+    for amount in range(2, 10):
+        endpoint_array = [list(constants) for _ in range(amount)]
+        _, return_code = setup_conf.set_conf(BaseTestTfs.configure_body_conf({"endpoints_array":endpoint_array}))
+        assert return_code == 200
+
+def check_data_test(setup_conf):
+    """
+        Test getting data from 2 endpoints at the same time
+    """
+    tag_msg1 = "ib_basic_debug"
+    tag_msg2 = "low_freq_debug"
+    simulation_endpoint1 = ["127.0.0.1", "csv/xcset/ib_basic_debug", 9007,
+                             50, tag_msg1, False, 'legacy']
+    simulation_endpoint2 = ["127.0.0.1", "csv/xcset/low_freq_debug", 9007,
+                             50, tag_msg2, False, 'legacy']
+    _, return_code = setup_conf.set_conf(BaseTestTfs.configure_body_conf(
+        {"endpoints_array":[simulation_endpoint1, simulation_endpoint2]}))
+    assert return_code == 200
+
+    data = setup_conf.read_data()
+    tag_msg_in_data = [False, False]
+    for msg in data.splitlines():
+        if tag_msg1 in msg:
+            tag_msg_in_data[0] = True
+        if tag_msg2 in msg:
+            tag_msg_in_data[1] = True
+    
+    assert tag_msg_in_data[0] and tag_msg_in_data[1],\
+        f"Cannot read the tag message from both endpoints: {tag_msg1}:{tag_msg_in_data[0]},"\
+            +f"{tag_msg2}:{tag_msg_in_data[1]}."

--- a/plugins/fluentd_telemetry_plugin/tests/stream_only_change_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/stream_only_change_test.py
@@ -1,0 +1,54 @@
+import pytest
+import time
+import pandas as pd
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    base_test.prepare_fluentd()
+    base_test.run_simulation(max_changing=1, interval=5.0)
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+
+def deep_check_test(setup_conf):
+    time.sleep(2)
+    # waiting for one message in the fluent
+    telemetry_url = setup_conf.get_simulation_url()[0]
+    telemetry_data = pd.read_csv(telemetry_url)
+
+    # convert to dataframe
+    plugin_data = setup_conf.extract_data_from_line(setup_conf.read_data())
+    plugin_df = pd.DataFrame(plugin_data)
+
+    # sort the dataframe so the rows will be in order
+    telemetry_data = telemetry_data.sort_values(by=['node_guid', 'port_num'])
+    plugin_df = plugin_df.sort_values(by=['node_guid', 'port_num'])
+
+    assert telemetry_data.equals(plugin_df), "deep_check show that dataframes are not equal"
+
+def get_new_data_test(setup_conf):
+    previous_data = setup_conf.read_data()
+    previous_df = pd.DataFrame(setup_conf.extract_data_from_line(previous_data))
+    previous_df = previous_df.sort_values(by=['node_guid', 'port_num'])
+    time.sleep(10)
+    now_data = setup_conf.read_data()
+    now_df = pd.DataFrame(setup_conf.extract_data_from_line(now_data))
+    now_df = now_df.sort_values(by=['node_guid', 'port_num'])
+
+    # checking that all is equal but the changing column
+    assert previous_df.iloc[:, 6:].equals(now_df.iloc[:, 6:]),\
+        "new data test: expected all the values but the changing column be the same, got difference."
+
+    # checking that the values on the changing columns did changed.
+    assert not (previous_df.iloc[:, 5] != now_df.iloc[:, 5]).all(),\
+        "new data test: expected a change on changing column, got all the values are equal between the changing."

--- a/plugins/fluentd_telemetry_plugin/tests/stream_test.py
+++ b/plugins/fluentd_telemetry_plugin/tests/stream_test.py
@@ -1,0 +1,61 @@
+import pytest
+from base_functions import BaseTestTfs
+
+@pytest.fixture(scope="module")
+def setup_conf():
+    """setup the environment for the tests
+
+    Yields:
+        BaseTestTfs: base test with all the functions
+    """
+    base_test = BaseTestTfs()
+    base_test.prepare_fluentd()
+    base_test.run_simulation()
+    result = base_test.run_server()
+    assert result > 0, "could not start the server"
+    yield base_test
+    base_test.stop_server()
+    base_test.stop_simulation()
+    base_test.stop_fluentd()
+
+def verify_bulk_test(setup_conf):
+    """Test bulk streaming
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf({"bulk_streaming":True}))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(bulk=True)
+    assert result, message
+
+def verify_non_bulk_test(setup_conf):
+    """Test not bulk streaming
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf({"bulk_streaming":False}))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(bulk=False)
+    assert result, message
+
+def verify_meta_test(setup_conf):
+    """Set meta information and test it
+    """
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf({"meta":
+            {"alias_node_description": "node_namex",
+            "alias_node_guid": "GUID",
+            "add_type": "csv"}}))
+    assert response_code == 200
+    result, message =  setup_conf.verify_streaming(meta="node_namex",constants="csv")
+    assert result, message
+
+def info_label_test(setup_conf):
+    """test the info label
+    """
+    result, message = setup_conf.verify_streaming(info_labels=True)
+    assert result, message
+
+def tag_msg_test(setup_conf):
+    """test the tag msg after changing it.
+    """
+    check_tag_msg = "pytest tag check"
+    _, response_code = setup_conf.set_conf(setup_conf.configure_body_conf({"tag_name":check_tag_msg}))
+    assert response_code == 200
+    result, message = setup_conf.verify_streaming(tag_msg=check_tag_msg)
+    assert result, message


### PR DESCRIPTION
## What
Adds pytest files into the TFS plugin tests, which will be activated when [PR](this https://github.com/Mellanox/ufm_sdk_3.0/pull/312)  will be inserted.

## Why ?
[Task](https://redmine.mellanox.com/issues/4349296)
Adding pytests for tfs plugin

## How ?
Each file looks for different aspects of the plugin functionality. The general idea of the split is used in verifications team.

## Testing ?
multi telemetry test - tests for running multi telemetries and seeing if the response is good for both of them.
stream test - test the stream data that includes all the items that are needed.
stream only change test - check the stream when running it only on the changes.

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
