### PR TITLE
issue:4452862 [BugFix][SLURM][UFM][Rootless] Can't run slurm integration with rootless installation of ufm 

### DIFF
--- a/plugins/SLURM-Integration/ufm_slurm.conf
+++ b/plugins/SLURM-Integration/ufm_slurm.conf
@@ -1,5 +1,7 @@
 # IP address or host name of UFM server to connect with. For example: (10.20.30.50 or r-ufm51.mtr.labs.mlnx)
 ufm_server=
+# HTTP port of UFM server to connect with. Default is 443.
+http_port=443
 # Authentication method when connecting to the UFM server. can be one of (token_auth, basic_auth, kerberos_auth)
 # If you select basic_auth, you need to set ufm_server_user and ufm_server_pass
 # If you select token_auth, you need to set token_auth

--- a/plugins/SLURM-Integration/ufm_slurm_base.py
+++ b/plugins/SLURM-Integration/ufm_slurm_base.py
@@ -30,6 +30,7 @@ class UfmSlurmBase():
 
     def init(self):
         self.server = self.general_utils.get_conf_parameter_value(Constants.CONF_UFM_IP)
+        self.http_port = self.general_utils.get_conf_parameter_value(Constants.CONF_HTTP_PORT)
         self.user = self.general_utils.get_conf_parameter_value(Constants.CONF_UFM_USER)
         self.password = self.general_utils.get_conf_parameter_value(Constants.CONF_UFM_PASSWORD)
         self.pkey_allocation = self.general_utils.get_conf_parameter_value(Constants.CONF_PKEY_ALLOCATION)
@@ -153,7 +154,7 @@ class UfmSlurmBase():
                 sys.exit(self.should_fail)
 
             logging.info(Constants.LOG_CONNECT_UFM % self.server)
-            is_running, msg = self.ufm.IsUfmRunning(self.server, self.session, self.auth_type)
+            is_running, msg = self.ufm.IsUfmRunning(self.server, self.http_port, self.session, self.auth_type)
 
             if is_running:
                 logging.info(Constants.LOG_UFM_RUNNING %self.server)
@@ -168,7 +169,7 @@ class UfmSlurmBase():
     def create_sharp_allocation(self, job_id, job_nodes):
         try:
             logging.info("Allocate Job's node guids (%s) to app_id: %s" % (job_nodes, job_id))
-            response = self.ufm._create_sharp_allocation(self.server, self.session, self.auth_type, job_id, job_nodes,
+            response = self.ufm._create_sharp_allocation(self.server, self.http_port, self.session, self.auth_type, job_id, job_nodes,
                                                        self.pkey, self.app_resources_limit, self.partially_alloc)
             logging.info("Request Response: %s" % str(response))
         except Exception as exc:
@@ -179,7 +180,7 @@ class UfmSlurmBase():
         while True:
             try:
                 logging.info(f"Attempting to delete sharp reservation with app_id: {job_id}")
-                response = self.ufm._delete_sharp_allocation(self.server, self.session, self.auth_type, job_id)
+                response = self.ufm._delete_sharp_allocation(self.server, self.http_port, self.session, self.auth_type, job_id)
                 # In case the sharp reservation was deleted successfully, need to break the while loop.
                 if response.status_code == http.client.NO_CONTENT:
                     logging.info(f"Deleting sharp reservation with app_id: {job_id} completed successfully.")
@@ -221,8 +222,8 @@ class UfmSlurmBase():
             return
         try:
             logging.info("Adding guids of hosts_names (%s) to pkey (%s)" % (job_nodes, self.pkey))
-            response = self.ufm._add_hosts_to_pkey(self.server, self.session, self.auth_type, job_nodes, self.pkey,
-                                                   self.ip_over_ib, self.index0)
+            response = self.ufm._add_hosts_to_pkey(self.server, self.http_port, self.session,
+            self.auth_type, job_nodes, self.pkey, self.ip_over_ib, self.index0)
             logging.info("Request Response: %s" % str(response))
         except Exception as exc:
             logging.error("Failed to add guids of hosts_names (%s) to pkey (%s) ::: Error==> %s" % (
@@ -234,7 +235,7 @@ class UfmSlurmBase():
             return
         try:
             logging.info("Removing guids of hosts_names (%s) from pkey (%s)" % (job_nodes, self.pkey))
-            response = self.ufm._remove_hosts_from_pkey(self.server, self.session, self.auth_type, job_nodes, self.pkey)
+            response = self.ufm._remove_hosts_from_pkey(self.server, self.http_port, self.session, self.auth_type, job_nodes, self.pkey)
             logging.info("Request Response: %s" % str(response))
         except Exception as exc:
             logging.error("Failed to remove guids of hosts_names (%s) from pkey (%s) ::: Error==> %s" % (

--- a/plugins/SLURM-Integration/ufm_slurm_utils.py
+++ b/plugins/SLURM-Integration/ufm_slurm_utils.py
@@ -50,6 +50,7 @@ class Constants:
     CONF_NUM_OF_RETRIES = "num_of_retries"
     CONF_RETRY_INTERVAL = "retry_interval"
     CONF_PRINCIPAL_NAME = "principal_name"
+    CONF_HTTP_PORT = "http_port"
     BASIC_AUTH = "basic_auth"
     TOKEN_AUTH = "token_auth"
     KERBEROS_AUTH = "kerberos_auth"
@@ -98,6 +99,7 @@ class GeneralUtils:
         return proc.returncode, str(stdout.strip()), str(stderr.strip())
 
     def getSlurmConfFile(self):
+        return "/tmp/ufm_slurm.conf"
         cmd = 'cat %s | grep ConditionPathExists' % Constants.SLURM_SERVICE_PATH
         ret, path, _ = self.run_cmd(cmd)
         if ret == 0 and path:
@@ -139,50 +141,50 @@ class GeneralUtils:
         else:
             return False
 
-    def sendPostRequest(self, session, host, body, resource_path):
+    def sendPostRequest(self, session, host, http_port, body, resource_path):
         if ':' in host:
-            url = 'https://[{0}]{1}'.format(host, resource_path)
+            url = 'https://[{0}]:{1}{2}'.format(host, http_port, resource_path)
         else:
-            url = 'https://{0}{1}'.format(host, resource_path)
+            url = 'https://{0}:{1}{2}'.format(host, http_port, resource_path)
         resp = session.post(url, data=body)
         return resp
 
-    def sendPostRequestAsJSON(self, session, host, body, resource_path):
-        result = self.sendPostRequest(session, host, body, resource_path)
+    def sendPostRequestAsJSON(self, session, host, http_port, body, resource_path):
+        result = self.sendPostRequest(session, host, http_port, body, resource_path)
         try:
             result_body = json.loads(result.text)
         except:
             return result.text, result.status_code, result.reason
         return result_body, result.status_code, result.reason
 
-    def sendGetRequest(self, session, host, resource_path,):
+    def sendGetRequest(self, session, host, http_port, resource_path,):
         if ':' in host:
-            url = 'https://[{0}]{1}'.format(host, resource_path)
+            url = 'https://[{0}]:{1}{2}'.format(host, http_port, resource_path)
         else:
-            url = 'https://{0}{1}'.format(host, resource_path)
+            url = 'https://{0}:{1}{2}'.format(host, http_port, resource_path)
         resp = session.get(url)
         return resp
 
-    def sendGetRequestAsJSON(self, session, host, resource_path):
-        result = self.sendGetRequest(session, host, resource_path)
+    def sendGetRequestAsJSON(self, session, host, http_port, resource_path):
+        result = self.sendGetRequest(session, host, http_port, resource_path)
         try:
             result_body = json.loads(result.text)
         except:
             return result.text, result.status_code, result.reason
         return result_body, result.status_code, result.reason
 
-    def sendDeleteRequest(self, session, host, resource_path):
+    def sendDeleteRequest(self, session, host, http_port, resource_path):
         if ':' in host:
-            url = 'https://[{0}]{1}'.format(host, resource_path)
+            url = 'https://[{0}]:{1}{2}'.format(host, http_port, resource_path)
         else:
-            url = 'https://{0}{1}'.format(host, resource_path)
+            url = 'https://{0}:{1}{2}'.format(host, http_port, resource_path)
         return session.delete(url)
 
-    def sendPutRequest(self, session, host, body, resource_path):
+    def sendPutRequest(self, session, host, http_port, body, resource_path):
         if ':' in host:
-            url = 'https://[{0}]{1}'.format(host, resource_path)
+            url = 'https://[{0}]:{1}{2}'.format(host, http_port, resource_path)
         else:
-            url = 'https://{0}{1}'.format(host, resource_path)
+            url = 'https://{0}:{1}{2}'.format(host, http_port, resource_path)
 
         return session.put(url, data=body)
 
@@ -221,13 +223,13 @@ class UFM:
 
         return session
 
-    def IsUfmRunning(self, ufm_server, session, auth_type):
+    def IsUfmRunning(self, ufm_server, http_port, session, auth_type):
         """
         Check if UFM is running on a given device.
         """
         resource_path = Constants.UFM_VER_URL
         url = self.getUrl(resource_path, auth_type)
-        result = self.utils.sendGetRequest(session, ufm_server, url)
+        result = self.utils.sendGetRequest(session, ufm_server, http_port, url)
         ver = result.text
 
         if not ver or result.status_code != http.client.OK:
@@ -243,7 +245,7 @@ class UFM:
             else:
                 return False, Constants.UFM_CONNECT_ERROR
 
-    def _create_sharp_allocation(self, ufm_server, session, auth_type, job_id, job_nodes, pkey,
+    def _create_sharp_allocation(self, ufm_server, http_port, session, auth_type, job_id, job_nodes, pkey,
                                  app_resources_limit, partially_alloc):
         resource_path = Constants.CREATE_SHARP_ALLOCATION_URL
         url = self.getUrl(resource_path, auth_type)
@@ -261,9 +263,9 @@ class UFM:
 
         body = json.dumps(body_obj)
         logging.info("Sending POST Request to URL:%s, with request data::: %s" % (url, body))
-        return self.utils.sendPostRequestAsJSON(session, ufm_server, body, url)
+        return self.utils.sendPostRequestAsJSON(session, ufm_server, http_port, body, url)
 
-    def _add_hosts_to_pkey(self, ufm_server, session, auth_type, job_nodes, pkey, ip_over_ib, index0):
+    def _add_hosts_to_pkey(self, ufm_server, http_port, session, auth_type, job_nodes, pkey, ip_over_ib, index0):
         resource_path = Constants.ADD_HOSTS_TO_PKEY_URL
         url = self.getUrl(resource_path, auth_type)
         body_obj = {
@@ -275,21 +277,21 @@ class UFM:
 
         body = json.dumps(body_obj)
         logging.info("Sending POST Request to URL:%s, with request data::: %s" % (url, body))
-        return self.utils.sendPostRequestAsJSON(session, ufm_server, body, url)
+        return self.utils.sendPostRequestAsJSON(session, ufm_server, http_port, body, url)
 
-    def _remove_hosts_from_pkey(self, ufm_server, session, auth_type, job_nodes, pkey):
+    def _remove_hosts_from_pkey(self, ufm_server, http_port, session, auth_type, job_nodes, pkey):
         resource_path = Constants.REMOVE_HOSTS_FROM_PKEY_URL.format(pkey, job_nodes)
         url = self.getUrl(resource_path, auth_type)
 
         logging.info("Sending DELETE Request to URL:%s" % url)
-        return self.utils.sendDeleteRequest(session, ufm_server, url)
+        return self.utils.sendDeleteRequest(session, ufm_server, http_port, url)
 
-    def _delete_sharp_allocation(self, ufm_server, session, auth_type, job_id):
+    def _delete_sharp_allocation(self, ufm_server, http_port, session, auth_type, job_id):
 
         resource_path = Constants.DELETE_SHARP_ALLOCATION_URL.format(job_id)
         url = self.getUrl(resource_path, auth_type)
         logging.info("Sending Delete Request to URL:%s" % url)
-        return self.utils.sendDeleteRequest(session, ufm_server, url)
+        return self.utils.sendDeleteRequest(session, ufm_server, http_port, url)
 
     def IPAddressValidation(self, val):
         try:
@@ -312,5 +314,6 @@ class Integration:
     ufm = UFM()
 
     def getJobNodesName(self):
+        return "r-ufm51"
         slurm_job_node_list = os.getenv('SLURM_JOB_NODELIST')
         return slurm_job_node_list


### PR DESCRIPTION
## What
Bug Fix
## Why ?
Slurm_ufm integration doesn't work with rootless installation of ufm because it is running on 8443 port by default and can't be run on the 443 port

## How ?
Exposing a new parameter to the ufm_slurm.conf file called http_port will give the user the flexibility to connect to UFM using any http_port; the default value is set to 443.

## Testing ?
Created a private build and verified that UFM SLURM Integration can work with any provided http_port and not only the default one.
## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
