### PR TITLE
issue:4846312 [CI] Move NDT plugin build to dind

### DIFF
--- a/.ci/cidemo-init.sh
+++ b/.ci/cidemo-init.sh
@@ -4,7 +4,7 @@ cd .ci
 # You can print specific environment variables here if required
 
 # Get the list of changed files
-changed_files=$(git diff --name-only remotes/origin/$ghprbTargetBranch)
+changed_files=$(git diff --name-only --ignore-submodules remotes/origin/$ghprbTargetBranch)
 
 # Check for changes excluding .gitmodules and root .ci directory
 changes_excluding_gitmodules_and_root_ci=$(echo "$changed_files" | grep -v -e '.gitmodules' -e '^scripts/' -e '.gitignore' -e '^\.ci/' -e '^\.github/workflows' -e '\utils' -e '\plugins/ufm_log_analyzer_plugin') #Removing ufm_log_analyzer_plugin as for now it does not need a formal build

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -22,6 +22,8 @@ credentials:
 volumes:
 #   - {mountPath: /var/run/docker.sock, hostPath: /var/run/docker.sock}
   - {hostPath: /auto/UFM, mountPath: /auto/UFM}
+  - {hostPath: /auto/sw/release/ufm, mountPath: /auto/sw/release/ufm}
+  - {hostPath: /labhome/swx-jenkins, mountPath: /var/home/swx-jenkins}
 
 runs_on_dockers:
    #- {file: 'plugins/UFM_NDT_Plugin/.ci/Dockerfile_static_tests_ub2004', arch: 'x86_64', name: 'swx_static', tag: '20230717'}

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -13,11 +13,15 @@ credentials:
   - {credentialsId: '2c8fd3fe-df05-4f6f-9d1f-f1896d611434', usernameVariable: 'REST_USER', passwordVariable: 'PASSWORD'}
   - {credentialsId: 'e4ba8d7a-d304-4c01-aff9-90de67d97efc', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN'}
 
-volumes:
-  - {mountPath: /var/run/docker.sock, hostPath: /var/run/docker.sock}
+# volumes:
+#   - {mountPath: /var/run/docker.sock, hostPath: /var/run/docker.sock}
+
 runs_on_dockers:
    #- {file: 'plugins/UFM_NDT_Plugin/.ci/Dockerfile_static_tests_ub2004', arch: 'x86_64', name: 'swx_static', tag: '20230717'}
    - {url: 'harbor.mellanox.com/swx-storage/ci-demo/x86_64/swx_static:20230717', name: 'swx_static', tag: '20230717', arch: 'x86_64'}
+   - {url: 'nbu-harbor.gtm.nvidia.com/ufm/ci/dind_ufm_x86_64:20250825', name: 'docker_builder_x86_64', arch: 'x86_64', category: 'tool'}
+   - {url: 'nbu-harbor.gtm.nvidia.com/ufm/ci/dind_ufm_aarch64:20250824', name: 'docker_builder_aarch64', arch: 'aarch64', category: 'tool'}
+
 runs_on_agents:
   - nodeLabel: 'UFM-POC'
 
@@ -53,8 +57,21 @@ steps:
 
 
   - name: build Plugin
-    agentSelector: "{nodeLabel: 'UFM-POC'}"
+    containerSelector: 
+     - "{name: 'docker_builder_x86_64'}"
+     - "{name: 'docker_builder_aarch64'}"
     run: |
+      set -x
+
+      # start docker daemon for dind
+      export DOCKER_HOST=unix:///run/docker.sock
+      nohup /usr/local/bin/dockerd-entrypoint.sh &>/var/log/docker.log &
+      while ! docker info &>/dev/null; do
+        echo "Waiting for docker daemon to start..."
+        sleep 1
+      done
+
+
       cd plugins/UFM_NDT_Plugin/build
       sudo bash -x ./docker_build.sh
       cp ufm-plugin-ndt* /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -13,9 +13,10 @@ credentials:
   - {credentialsId: '2c8fd3fe-df05-4f6f-9d1f-f1896d611434', usernameVariable: 'REST_USER', passwordVariable: 'PASSWORD'}
   - {credentialsId: 'e4ba8d7a-d304-4c01-aff9-90de67d97efc', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN'}
 
-# volumes:
+volumes:
 #   - {mountPath: /var/run/docker.sock, hostPath: /var/run/docker.sock}
-
+  - {hostPath: /auto/UFM, mountPath: /auto/UFM}
+  
 runs_on_dockers:
    #- {file: 'plugins/UFM_NDT_Plugin/.ci/Dockerfile_static_tests_ub2004', arch: 'x86_64', name: 'swx_static', tag: '20230717'}
    - {url: 'harbor.mellanox.com/swx-storage/ci-demo/x86_64/swx_static:20230717', name: 'swx_static', tag: '20230717', arch: 'x86_64'}

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -193,7 +193,8 @@ steps:
 
 pipeline_start:
   run: |
-    sudo mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
+    sudo -u swx-jenkins 
+    mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
 
 pipeline_stop:
   run: |

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -78,7 +78,8 @@ steps:
         sleep 1
       done
 
-      mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
+      sudo -u swx-jenkins mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
+      
       cd plugins/UFM_NDT_Plugin/build
       bash -x ./docker_build.sh
       cp ufm-plugin-ndt* /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -193,7 +193,7 @@ steps:
 
 pipeline_start:
   run: |
-    sudo mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
+    mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
 
 pipeline_stop:
   run: |

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -72,7 +72,7 @@ steps:
         sleep 1
       done
 
-
+      mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
       cd plugins/UFM_NDT_Plugin/build
       bash -x ./docker_build.sh
       cp ufm-plugin-ndt* /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/
@@ -189,12 +189,6 @@ steps:
       # clean simulator files
       ssh -4 root@${SERVER_HOST} 'rm -rf /root/simulation; rm -rf /tmp/simulator.log'
     parallel: false
-
-
-pipeline_start:
-  run: |
-    sudo -u swx-jenkins 
-    mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
 
 pipeline_stop:
   run: |

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -83,6 +83,11 @@ steps:
       sudo -u swx-jenkins mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
       
       cd plugins/UFM_NDT_Plugin/build
+      git config --global --add safe.directory ${WORKSPACE}
+      git config --global --add safe.directory ${WORKSPACE}/plugins/UFM_NDT_Plugin/ufm_sim_web_service/ndt-ui/sms-ui-suite
+      git config --global --add safe.directory ${WORKSPACE}/plugins/bright_plugin/src/bright-ui/sms-ui-suite
+      git config --global --add safe.directory ${WORKSPACE}/ufm_sdk_tools
+      git config --global --add safe.directory ${WORKSPACE}/utils/fluentd
       bash -x ./docker_build.sh
       cp ufm-plugin-ndt* /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/
     parallel: false

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -74,7 +74,7 @@ steps:
 
 
       cd plugins/UFM_NDT_Plugin/build
-      sudo bash -x ./docker_build.sh
+      bash -x ./docker_build.sh
       cp ufm-plugin-ndt* /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/
     parallel: false
 
@@ -193,7 +193,7 @@ steps:
 
 pipeline_start:
   run: |
-    mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
+    sudo mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
 
 pipeline_stop:
   run: |

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -90,7 +90,6 @@ steps:
       git config --global --add safe.directory ${WORKSPACE}/utils/fluentd
       
       bash -x ./docker_build.sh ${BUILD_ID} /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/
-      cp ufm-plugin-ndt* /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/
     parallel: false
 
 

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -88,7 +88,8 @@ steps:
       git config --global --add safe.directory ${WORKSPACE}/plugins/bright_plugin/src/bright-ui/sms-ui-suite
       git config --global --add safe.directory ${WORKSPACE}/ufm_sdk_tools
       git config --global --add safe.directory ${WORKSPACE}/utils/fluentd
-      bash -x ./docker_build.sh
+      
+      bash -x ./docker_build.sh ${BUILD_ID} /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/
       cp ufm-plugin-ndt* /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/
     parallel: false
 

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -68,7 +68,6 @@ steps:
   - name: build Plugin
     containerSelector: 
      - "{name: 'docker_builder_x86_64'}"
-     - "{name: 'docker_builder_aarch64'}"
     run: |
       set -x
 

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -7,7 +7,13 @@ registry_auth: swx-storage
 step_allow_single_selector: true
 
 kubernetes:
-  cloud: swx-k8s-spray
+  cloud: il-ipp-blossom-prod
+  nodeSelector: 'kubernetes.io/arch=amd64,kubernetes.io/arch=aarch64'
+  namespace: swx
+  caps_add: "[ IPC_LOCK, SYS_RESOURCE ]"
+  limits: "{memory: 30Gi, cpu: 12000m, ephemeral-storage: 25Gi}"
+  requests: "{memory: 12Gi ,cpu: 8000m, ephemeral-storage: 10Gi}"
+  privileged: true
 
 credentials:
   - {credentialsId: '2c8fd3fe-df05-4f6f-9d1f-f1896d611434', usernameVariable: 'REST_USER', passwordVariable: 'PASSWORD'}

--- a/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
+++ b/plugins/UFM_NDT_Plugin/.ci/ci_matrix.yaml
@@ -16,7 +16,7 @@ credentials:
 volumes:
 #   - {mountPath: /var/run/docker.sock, hostPath: /var/run/docker.sock}
   - {hostPath: /auto/UFM, mountPath: /auto/UFM}
-  
+
 runs_on_dockers:
    #- {file: 'plugins/UFM_NDT_Plugin/.ci/Dockerfile_static_tests_ub2004', arch: 'x86_64', name: 'swx_static', tag: '20230717'}
    - {url: 'harbor.mellanox.com/swx-storage/ci-demo/x86_64/swx_static:20230717', name: 'swx_static', tag: '20230717', arch: 'x86_64'}
@@ -193,7 +193,7 @@ steps:
 
 pipeline_start:
   run: |
-    mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
+    sudo mkdir -p /auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}
 
 pipeline_stop:
   run: |

--- a/plugins/UFM_NDT_Plugin/README.md
+++ b/plugins/UFM_NDT_Plugin/README.md
@@ -24,6 +24,7 @@ Log file ndt.log is located in /opt/ufm/files/log on the host.
 
 ------------------------------------------------------------------------------------------------------------
 
+
 **Usage**
 
 Example of a test scenario (positive flow):

--- a/plugins/UFM_NDT_Plugin/README.md
+++ b/plugins/UFM_NDT_Plugin/README.md
@@ -24,7 +24,6 @@ Log file ndt.log is located in /opt/ufm/files/log on the host.
 
 ------------------------------------------------------------------------------------------------------------
 
-
 **Usage**
 
 Example of a test scenario (positive flow):

--- a/plugins/UFM_NDT_Plugin/build/docker_build.sh
+++ b/plugins/UFM_NDT_Plugin/build/docker_build.sh
@@ -7,6 +7,12 @@ set -eE
 #  exit
 #fi
 
+if [ -n "$JENKINS_URL" ]; then
+    export CI_PREFIX="sudo -u swx-jenkins "
+else
+    export CI_PREFIX=""
+fi
+
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 PARENT_DIR=$(realpath "${SCRIPT_DIR}/../../../")
 

--- a/plugins/UFM_NDT_Plugin/build/docker_build.sh
+++ b/plugins/UFM_NDT_Plugin/build/docker_build.sh
@@ -91,13 +91,18 @@ function build_docker_image()
     docker images | grep ${image_with_prefix}
     printf "\n\n\n"
 
-    echo "docker save ${image_with_prefix_and_version} | gzip > ${out_dir}/${full_image_version}.${arch}.gz"
-    docker save ${image_with_prefix_and_version} | gzip > ${out_dir}/${full_image_version}.${arch}.gz
+    echo "docker save ${image_with_prefix_and_version} | gzip > ${full_image_version}.${arch}.gz"
+    docker save ${image_with_prefix_and_version} | gzip > ${full_image_version}.${arch}.gz
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
         echo "Failed to save image"
         return $exit_code
     fi
+    
+    if [ $out_dir != "."  ]; then
+      $CI_PREFIX cp -r ${full_image_version}.${arch}.gz ${out_dir}
+    fi
+
     if [ "$keep_image" != "y" -a "$keep_image" != "Y" ]; then
         docker image rm -f ${image_with_prefix_and_version}
     fi


### PR DESCRIPTION
## What
Switch NDT plugin CI build step to use Docker-in-Docker (dind) instead of mounting the host's Docker socket.

## Why
Upgrading infra, moving to dind and adding ARM. 

## How
- Replaced `/var/run/docker.sock` volume mount with `/auto/UFM` mount for artifact storage
- Added dind daemon startup sequence in the build step (wait for Docker daemon to be ready before building)
- Added artifact copy step to persist build output to `/auto/UFM/tmp/${JOB_NAME}/${BUILD_ID}/`

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
