### PR TITLE
issue:4985416 [Feature] propagate per-plugin env into init container

### DIFF
--- a/ufm-plugin-helm-template/templates/plugin-deployment.yaml
+++ b/ufm-plugin-helm-template/templates/plugin-deployment.yaml
@@ -100,6 +100,9 @@ spec:
                 configMapKeyRef:
                   name: {{ $ufmFullname }}-config
                   key: UFM_VERSION
+            {{- with $plugin.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           securityContext:
             privileged: false
             {{- if and $pluginRdma.resourceName (ne (toString $pluginRdma.resourceCount) "0") }}


### PR DESCRIPTION
## What
- `ufm-plugin-helm-template/templates/plugin-deployment.yaml`: inject the per-plugin `env` list (`plugins.entries.<name>.env`) into the init container's `env:` block, immediately after the fixed `UFM_VERSION` entry.

## Why
Today per-plugin `env` flows only to the main container. Init containers see only `UFM_VERSION` (sourced from the UFM ConfigMap). A plugin's `/init.sh` has no values-driven way to receive install-time configuration.

Concrete driver: UTM introduces a `UTM_CONFIG_OVERRIDES` env var (see companion PR in `Mellanox-lab/utm-plugin#25`) that seeds `/config/utm_config.ini` on first pod start from the operator's Helm values. That env var is currently invisible to UTM's init container, so the seeding path silently no-ops. Validated on k3s: before this change the init log skipped the `user-override:` section entirely; after this change the init log correctly applies user overrides.

More broadly, this closes a gap any plugin that does declarative init-time configuration will hit. It is a one-line, backward-compatible addition.

## How
- **`templates/plugin-deployment.yaml`**: add a `{{- with $plugin.env }}{{- toYaml . | nindent 12 }}{{- end }}` block inside `initContainers[0].env`, directly after the existing `UFM_VERSION` entry. Indentation matches the main container's existing `env` injection.

### Backward compatibility
- Plugins that do not set `plugins.entries.<name>.env` have the same init-container env as before (only `UFM_VERSION`).
- No changes to `values.schema.json` — `env` is already a free-form array on each plugin entry.
- No changes to any other template or helper.
- Chart version not bumped in this PR (per repo conventions for minor additions); bump on next release cut.

### Companion PR
- `Mellanox-lab/utm-plugin#25` — UTM's init.sh and `utm-plugin-values.yaml` rely on this propagation.

## Testing
Executed end-to-end on a 2-node k3s test cluster (`mtvr-ufm-boaz-01`/`02`) with UFM Enterprise 6.25.0-6398 already deployed:

1. **Helm template dry-run** confirms `UTM_CONFIG_OVERRIDES` now renders into `initContainers[0].env`:
   ```
   initContainers:
     - name: utm-init
       env:
         - name: UFM_VERSION
             valueFrom: ...
         - name: UTM_CONFIG_OVERRIDES
           value: |
             [general]
             log_level=info
   ```
2. **Helm install** of the UTM plugin with `utm-plugin-values.yaml` containing `UTM_CONFIG_OVERRIDES`:
   - Init container log shows the new flow working:
     ```
     [UTM Init] Seeding user config overrides from env var UTM_CONFIG_OVERRIDES
     [UTM Init] user-override: general/log_level=info
     [UTM Init] Applying K8s-required overrides
     ...
     [UTM Init] First-time init complete
     ```
   - Before this change (same values, same image): the `Seeding...` and `user-override:` lines were absent — the env var never reached init.

3. **Regression**: plugins with no `env` entry continue to render an init container carrying only `UFM_VERSION`; no behavior change for existing plugins. `helm lint` on the chart passes.

4. **End-to-end**: with the env var propagated, UTM's init seeds `utm_config.ini` including an operator-provided `[ufm]` block and token file path, the main container reads the token from a mounted Secret, and UFM API calls succeed with HTTP 200 using `auth_method: token` via K8s Service DNS.