### PR TITLE
issue:5035709 [Feature] Update UFM SLULRM Integration to use only PKEYs API

### DIFF
--- a/plugins/SLURM-Integration/README.md
+++ b/plugins/SLURM-Integration/README.md
@@ -81,10 +81,12 @@ settings need to be adjusted to make the UFM-SLURM Integration function properly
 	   ufm_server_pass:       UFM server user password.
        pkey_allocation:       When set to true, UFM–SLURM Integration will allocate a PKEY for the SLURM job. Otherwise, it will use the default management PKEY: 0x7fff.
        pkey_allocation_mode:  PKEY allocation mode: one of {static, dynamic}.
-                              - static  : use a statically assigned PKEY when creating a new PKEY.
-                              - dynamic : use dynamic assignment when creating a new PKEY based on the slurm-job-id.
+                              - static  : a single, pre-configured PKEY (from the 'pkey' parameter, or the
+                                          default management PKEY 0x7fff if unset) is used for all SLURM jobs.
+                              - dynamic : a per-job PKEY is derived from the SLURM job ID (wrapped into
+                                          0x1-0x7ffe), providing per-job isolation and a natural fit with
+                                          UFM's auto_reservation_by_pkey flow.
 	   pkey:                  Used only when pkey_allocation_mode=static. If not set, the default management PKEY (0x7fff) will be used.
-	   partially_alloc:       Whether to allow or not allow partial allocation of nodes
        auth_type:             One of (token_auth, basic_auth, kerberos_auth) by default it token_auth
 	   token:                 If you set auth_type to be token_auth you need to set generated token. Please see Generate token_auth section.
        principal_nam:         principal name to be used in kerberos authentication when you set auth_type to be kerberos_auth.
@@ -107,10 +109,11 @@ Running
 After the installation and deployment of UFM-SLURM Integration, the integration should automatically handle every submitted SLURM job.
 
     - Use the SLURM controller to submit a new SLURM job, for example: sbatch -N2 batch1.sh.
-    - On the UFM side, a new SHArP reservation will be created based on the job ID and the job nodes if the
-      sharp_allocation parameter in the ufm_slurm.conf file is set to true.
-    - A new pkey containing all the ports of the job nodes will be created to allow the SHArP nodes to communicate on top of it.
-    - After the SLURM job is completed, UFM deletes the created SHArP reservation and pkey.
+    - A new PKEY containing all the ports of the job nodes will be created (based on pkey_allocation_mode) to allow the job nodes to communicate.
+    - On the UFM side, the SHArP reservation is now managed automatically via the auto_reservation_by_pkey flow,
+      based on the PKEY membership changes performed by the prolog/epilog (add_hosts_to_pkey / remove_hosts_from_pkey).
+      No explicit SHArP reservation API calls are made from the integration.
+    - After the SLURM job is completed, the hosts are removed from the PKEY and UFM tears down the associated SHArP reservation automatically.
     - From the time a job is submitted by the SLURM server until its completion, a log file called /var/log/slurm/ufm_slurm.log
       records all actions and errors that occur during execution. This log file location can be changed by modifying the
       log_file_name parameter in the UFM_SLURM configuration file located at /etc/slurm/ufm_slurm.conf.

--- a/plugins/SLURM-Integration/ufm_slurm.conf
+++ b/plugins/SLURM-Integration/ufm_slurm.conf
@@ -26,15 +26,7 @@ pkey_allocation_mode=static
 # Applicable only when assigning a static PKEY for all SLURM jobs.
 # If the pkey_allocation_mode is set to static, and the pkey is not set, the default management PKEY (0x7fff) will be used.
 pkey=
-# By setting sharp_allocation to True, UFM SLURM Integration will create new SHArP allocation with all SLURM job IDs allocated to hosts.
-sharp_allocation=false
-# By setting partially_alloc to false, UFM SHARP allocation API will fail the SHArP allocation request if at least one node does not exist in the fabric.
-partially_alloc=true
 # Name of UFM-SLURM integration logging file
 log_file_name=/var/log/slurm/ufm_slurm.log
 # by default, the value is set to 0, which means, allowing Slurm job to continue running even if the ufm-prolog.sh or ufm-epilog.sh exit with non-zero status.
 fail_slurm_job_upon_failure=0
-# Specifies the number of retry attempts to delete sharp reservation before giving up. 0 value means retry forever.
-num_of_retries=5
-# Represent the time interval (in seconds) between retry attempts.
-retry_interval=2

--- a/plugins/SLURM-Integration/ufm_slurm_base.py
+++ b/plugins/SLURM-Integration/ufm_slurm_base.py
@@ -15,7 +15,7 @@
 # Author: Ibrahimbar
 # Author: Anas Badaha
 
-import sys, time, http
+import sys
 import argparse
 import logging
 from ufm_slurm_utils import UFM, GeneralUtils, Integration, Constants
@@ -49,20 +49,6 @@ class UfmSlurmBase():
             self.index0 = False
         if not self.https_port:
             self.https_port = "443"
-        self.sharp_allocation = self.general_utils.get_conf_parameter_value(Constants.CONF_SHARP_ALLOCATION)
-        self.sharp_allocation = self._toBoolean(self.sharp_allocation, Constants.CONF_SHARP_ALLOCATION, False)
-        self.partially_alloc = self.general_utils.get_conf_parameter_value(Constants.CONF_PARTIALLY_ALLOC)
-        self.partially_alloc = self._toBoolean(self.partially_alloc, Constants.CONF_PARTIALLY_ALLOC, True)
-        self.app_resources_limit = self.general_utils.get_conf_parameter_value(Constants.CONF_APP_RESOURCES_LIMIT)
-        if self.app_resources_limit and int(self.app_resources_limit) < -1:
-            logging.error(
-                "app_resources_limit param must be an integer number greater than -1, (got {0}), using default value: - 1".format(
-                    self.app_resources_limit))
-            self.app_resources_limit = -1
-        else:
-            self.app_resources_limit = -1
-        self.num_of_retries = int(self.general_utils.get_conf_parameter_value(Constants.CONF_NUM_OF_RETRIES))
-        self.retry_interval = int(self.general_utils.get_conf_parameter_value(Constants.CONF_RETRY_INTERVAL))
         self.is_in_debug_mode = self.general_utils.is_debug_mode()
 
     def get_pkey_name(self, job_id):
@@ -167,56 +153,6 @@ class UfmSlurmBase():
         except Exception as exc:
             logging.error(Constants.LOG_ERROR_UFM_CONNECT % str(exc) )
             sys.exit(self.should_fail)
-
-    def create_sharp_allocation(self, job_id, job_nodes):
-        try:
-            logging.info("Allocate Job's node guids (%s) to app_id: %s" % (job_nodes, job_id))
-            response = self.ufm._create_sharp_allocation(self.server, self.https_port, self.session, self.auth_type, job_id, job_nodes,
-                                                       self.pkey, self.app_resources_limit, self.partially_alloc)
-            logging.info("Request Response: %s" % str(response))
-        except Exception as exc:
-            logging.error("Failed to allocate job's node %s to pkey::: Error==> %s" % (job_nodes, exc))
-
-    def delete_sharp_allocation(self, job_id):
-        left_retries = self.num_of_retries
-        while True:
-            try:
-                logging.info(f"Attempting to delete sharp reservation with app_id: {job_id}")
-                response = self.ufm._delete_sharp_allocation(self.server, self.https_port, self.session, self.auth_type, job_id)
-                # In case the sharp reservation was deleted successfully, need to break the while loop.
-                if response.status_code == http.client.NO_CONTENT:
-                    logging.info(f"Deleting sharp reservation with app_id: {job_id} completed successfully.")
-                    break
-                # In case the sharp reservation was not found, need to break the while loop as well.
-                if response.status_code == http.client.NOT_FOUND:
-                    logging.warning(f"Deleting sharp reservation failed, sharp reservation with app_id: "
-                                    f"{job_id} is not found!")
-                    break
-                # In case the deletion of sharp reservation failed. (
-                # for example: in case of timeout and any other bad request)
-                else:
-                    logging.error(f"Deleting sharp reservation with app_id: {job_id} failed! "
-                                  f"status_code: {response.status_code}, response: {response.text}")
-                    # handle the scenario where num_of_retries in ufm_slurm.conf file is set to 0,
-                    # indicating that I need to retry the deletion indefinitely.
-                    if self.num_of_retries == 0:
-                        logging.info(f"Retrying to delete sharp reservation with app_id: {job_id} in "
-                                     f"{self.retry_interval} seconds...")
-                        time.sleep(self.retry_interval)
-                    # handle the scenario where num_of_retries in ufm_slurm.conf file is set to Non-zero value,
-                    # indicating that I need to retry the deletion equal to num_of_retries.
-                    elif left_retries > 0:
-                        logging.info(f"Retrying in {self.retry_interval} seconds... (Retries left: {left_retries})")
-                        left_retries -= 1
-                        time.sleep(self.retry_interval)
-                    # In case number of left_retries finished without succeeding to delete the sharp reservation, needs
-                    # to exit the while loop after adding an appropriate error message to log file.
-                    else:
-                        logging.error(f"No more retries. Failed to delete sharp reservation {job_id} "
-                                      f"after {self.num_of_retries} attempts.")
-                        break
-            except Exception as exc:  # In case of getting any unexpected error, need to write it to log file.
-                logging.error(f"Deleting sharp reservation with app_id {job_id} Failed! got exception ==> {exc}")
 
     def add_hosts_to_pkey(self, job_nodes):
         if not job_nodes or not self.pkey:

--- a/plugins/SLURM-Integration/ufm_slurm_epilog.py
+++ b/plugins/SLURM-Integration/ufm_slurm_epilog.py
@@ -41,8 +41,6 @@ if __name__ == '__main__':
         slurm_job_nodelist = epilog.get_job_nodes()
         if epilog.pkey_allocation:
             epilog.remove_hosts_from_pkey(slurm_job_nodelist)
-        if epilog.sharp_allocation:
-            epilog.delete_sharp_allocation(epilog.args.job_id)
     except Exception as exc:
         logging.error(
         Constants.LOG_ERR_EPILOG % str(exc))

--- a/plugins/SLURM-Integration/ufm_slurm_prolog.py
+++ b/plugins/SLURM-Integration/ufm_slurm_prolog.py
@@ -46,8 +46,6 @@ if __name__ == '__main__':
         slurm_job_nodelist = prolog.get_job_nodes()
         if prolog.pkey_allocation:
             prolog.add_hosts_to_pkey(slurm_job_nodelist)
-        if prolog.sharp_allocation:
-            prolog.create_sharp_allocation(prolog.args.job_id, slurm_job_nodelist)
         logging.info("UFM-Slurm-Prolog time: %.1f seconds" % (time.time() - all_time_start))
     except Exception as exc:
         logging.error(

--- a/plugins/SLURM-Integration/ufm_slurm_utils.py
+++ b/plugins/SLURM-Integration/ufm_slurm_utils.py
@@ -42,13 +42,8 @@ class Constants:
     DYNAMIC_PKEY_ALLOCATION_MODE = 'dynamic'
     CONF_IP_OVER_IB_PARAM = 'ip_over_ib'
     CONF_INDEX0_PARAM = 'index0'
-    CONF_SHARP_ALLOCATION = 'sharp_allocation'
-    CONF_PARTIALLY_ALLOC = "partially_alloc"
-    CONF_APP_RESOURCES_LIMIT = 'app_resources_limit'
     CONF_LOGFILE_NAME = 'log_file_name'
     CONF_DEBUG_MODE = 'debug_mode'
-    CONF_NUM_OF_RETRIES = "num_of_retries"
-    CONF_RETRY_INTERVAL = "retry_interval"
     CONF_PRINCIPAL_NAME = "principal_name"
     CONF_HTTPS_PORT = "https_port"
     BASIC_AUTH = "basic_auth"
@@ -58,8 +53,6 @@ class Constants:
     LS_JOB_NAME = 'slurm_job_'
     DEF_LOG_FILE = 'ufm_slurm.log'
     UFM_VER_URL = "/ufmRest/app/ufm_version"
-    CREATE_SHARP_ALLOCATION_URL = "/ufmRest/app/sharp/resources"
-    DELETE_SHARP_ALLOCATION_URL = "/ufmRest/app/sharp/resources/{0}"
     ADD_HOSTS_TO_PKEY_URL = "/ufmRest/resources/pkeys/hosts"
     REMOVE_HOSTS_FROM_PKEY_URL = "/ufmRest/resources/pkeys/{0}/hosts/{1}"
     UFM_NOT_RESPONDING = 'UFM server is not responding'
@@ -244,26 +237,6 @@ class UFM:
             else:
                 return False, Constants.UFM_CONNECT_ERROR
 
-    def _create_sharp_allocation(self, ufm_server, https_port, session, auth_type, job_id, job_nodes, pkey,
-                                 app_resources_limit, partially_alloc):
-        resource_path = Constants.CREATE_SHARP_ALLOCATION_URL
-        url = self.getUrl(resource_path, auth_type)
-        if not partially_alloc:
-            url = url + "?partially_alloc=false"
-
-        body_obj = {
-            "app_id": job_id,
-            "hosts_names": job_nodes,
-            "app_resources_limit": app_resources_limit
-        }
-
-        if pkey:
-            body_obj["pkey"] = pkey
-
-        body = json.dumps(body_obj)
-        logging.info("Sending POST Request to URL:%s, with request data::: %s" % (url, body))
-        return self.utils.sendPostRequestAsJSON(session, ufm_server, https_port, body, url)
-
     def _add_hosts_to_pkey(self, ufm_server, https_port, session, auth_type, job_nodes, pkey, ip_over_ib, index0):
         resource_path = Constants.ADD_HOSTS_TO_PKEY_URL
         url = self.getUrl(resource_path, auth_type)
@@ -283,13 +256,6 @@ class UFM:
         url = self.getUrl(resource_path, auth_type)
 
         logging.info("Sending DELETE Request to URL:%s" % url)
-        return self.utils.sendDeleteRequest(session, ufm_server, https_port, url)
-
-    def _delete_sharp_allocation(self, ufm_server, https_port, session, auth_type, job_id):
-
-        resource_path = Constants.DELETE_SHARP_ALLOCATION_URL.format(job_id)
-        url = self.getUrl(resource_path, auth_type)
-        logging.info("Sending Delete Request to URL:%s" % url)
         return self.utils.sendDeleteRequest(session, ufm_server, https_port, url)
 
     def IPAddressValidation(self, val):


### PR DESCRIPTION
## What
Update the UFM ↔ SLURM integration to rely solely on the PKEYs API, removing the direct SHArP reservation API usage. The prolog/epilog now only add/remove hosts from a PKEY, and UFM's `auto_reservation_by_pkey` flow handles the SHArP reservation lifecycle automatically.

## Why ?
Tracked by Redmine issue **5035709**. UFM now supports `auto_reservation_by_pkey`, which creates/tears down SHArP reservations automatically based on PKEY membership changes. Keeping a parallel SHArP-reservation code path in the SLURM integration is:
- redundant (two sources of truth for reservations),
- error-prone (custom retry loop for delete, partial-allocation flags), and
- harder to maintain than a single PKEY-based flow.

Switching to PKEYs-only simplifies the integration, removes ~100 lines of duplicated logic, and aligns the plugin with UFM's current recommended flow.

## How ?
- Prolog: `add_hosts_to_pkey(job_nodes)` only — UFM auto-creates the SHArP reservation from the PKEY.
- Epilog: `remove_hosts_from_pkey(job_nodes)` only — UFM auto-tears down the SHArP reservation.
- `pkey_allocation_mode`:
  - `static`: single pre-configured PKEY (`pkey` param, or default `0x7fff`) for all jobs.
  - `dynamic`: per-job PKEY derived from the SLURM job ID (wrapped into `0x1–0x7ffe`).
- All SHArP-specific config keys, constants, URLs, and helper methods are deleted.

## Testing ?
- Manual end-to-end with SLURM submitting jobs against a UFM that has `auto_reservation_by_pkey` enabled:
  - `static` mode: verified hosts added/removed from the configured PKEY and that UFM created/deleted the corresponding SHArP reservation automatically.
  - `dynamic` mode: verified per-job PKEY is created from the job ID and reservation lifecycle follows PKEY membership.
- Verified `/var/log/slurm/ufm_slurm.log` shows only PKEY add/remove calls and no SHArP reservation API calls.
- No unit tests added (existing plugin has no unit-test suite for this module).

## Special triggers
* ` + "`bot:retest`" + ` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ` + "`bot:upgrade`" + ` run additional update tests