### PR TITLE
state-mirror (2/4): storage backends + clients

### DIFF
--- a/ufm-state-mirror/state_mirror/k8s_client.py
+++ b/ufm-state-mirror/state_mirror/k8s_client.py
@@ -1,0 +1,132 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Kubernetes ConfigMap API adapter for the ConfigMap backend (HLD 5.3.x).
+
+Bridges :class:`state_mirror.store.ConfigMapStore` (which speaks a tiny,
+dict-oriented :class:`~state_mirror.store.ConfigMapApi` protocol) to the real
+``kubernetes`` client. All translation to/from ``V1ConfigMap`` and the
+``404 -> None`` mapping lives here so the store stays backend-neutral and unit
+testable with a fake.
+
+The ``kubernetes`` package is imported lazily (inside the factory / methods),
+matching redis-py's treatment in :mod:`state_mirror.redis_client`, so importing
+the store does not require the dependency to be installed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+_NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+
+class K8sConfigMapApi:
+    """Namespace-bound adapter over ``CoreV1Api`` for ConfigMap CRUD.
+
+    Returns ``None`` from :meth:`read_cm` and silently absorbs ``404`` from
+    :meth:`delete_cm` so the store's bootstrap/idempotent paths work; every
+    other ``ApiException`` propagates and is classified by the store.
+    """
+
+    def __init__(self, core_v1, namespace: str):
+        self._api = core_v1
+        self._ns = namespace
+
+    def read_cm(self, name: str):
+        from kubernetes.client.exceptions import ApiException
+
+        try:
+            cm = self._api.read_namespaced_config_map(name, self._ns)
+        except ApiException as exc:
+            if exc.status == 404:
+                return None
+            raise
+        return self._to_dict(cm)
+
+    def write_cm(self, name, *, labels, annotations, data, binary_data) -> None:
+        from kubernetes import client
+        from kubernetes.client.exceptions import ApiException
+
+        body = client.V1ConfigMap(
+            metadata=client.V1ObjectMeta(
+                name=name,
+                namespace=self._ns,
+                labels=labels or None,
+                annotations=annotations or None,
+            ),
+            data=data or None,
+            binary_data=binary_data or None,
+        )
+        # The sidecar is the sole writer of these objects, so a last-write-wins
+        # replace is safe; fall back to create when the object does not exist.
+        try:
+            self._api.replace_namespaced_config_map(name, self._ns, body)
+        except ApiException as exc:
+            if exc.status == 404:
+                self._api.create_namespaced_config_map(self._ns, body)
+            else:
+                raise
+
+    def delete_cm(self, name: str) -> None:
+        from kubernetes.client.exceptions import ApiException
+
+        try:
+            self._api.delete_namespaced_config_map(name, self._ns)
+        except ApiException as exc:
+            if exc.status != 404:
+                raise
+
+    def list_cms(self, label_selector: str) -> list[dict]:
+        resp = self._api.list_namespaced_config_map(self._ns, label_selector=label_selector)
+        return [self._to_dict(cm) for cm in resp.items]
+
+    @staticmethod
+    def _to_dict(cm) -> dict:
+        meta = cm.metadata
+        return {
+            "name": meta.name,
+            "annotations": dict(meta.annotations or {}),
+            "data": dict(cm.data or {}),
+            "binary_data": dict(cm.binary_data or {}),
+        }
+
+
+def detect_namespace() -> str:
+    """Resolve the namespace to write ConfigMaps into.
+
+    Prefers an explicit env override, then the pod's projected namespace via the
+    downward API (``POD_NAMESPACE``), then the serviceaccount token's namespace
+    file, falling back to ``default``.
+    """
+    ns = os.environ.get("STATE_MIRROR_NAMESPACE") or os.environ.get("POD_NAMESPACE")
+    if ns:
+        return ns.strip()
+    try:
+        with open(_NAMESPACE_FILE, encoding="utf-8") as fh:
+            return fh.read().strip()
+    except OSError:
+        log.warning("could not read %s; defaulting namespace to 'default'", _NAMESPACE_FILE)
+        return "default"
+
+
+def configmap_api_from_env() -> K8sConfigMapApi:
+    """Build a :class:`K8sConfigMapApi` using in-cluster config (HLD 5.3.x)."""
+    from kubernetes import client, config
+
+    config.load_incluster_config()
+    namespace = detect_namespace()
+    log.info("ConfigMap backend bound to namespace %s", namespace)
+    return K8sConfigMapApi(client.CoreV1Api(), namespace)

--- a/ufm-state-mirror/state_mirror/redis_client.py
+++ b/ufm-state-mirror/state_mirror/redis_client.py
@@ -1,0 +1,134 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Redis/Valkey client construction with Sentinel-aware master discovery
+(HLD 5.2, 8.6).
+
+The sidecar always writes to the *current* Redis master. Redis/Valkey is
+bring-your-own (UFM does not deploy it): when the operator points the sidecar
+at a Sentinel-managed deployment, the master is discovered through Sentinel so a
+failover is handled by re-resolving ``master_for`` rather than reconnecting to a
+fixed address. A direct (non-Sentinel) endpoint is also supported for a
+single-node Redis.
+
+redis-py is imported lazily so the rest of the package (classifier, wire,
+handlers, health) stays import-light and unit testable without the dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    return os.environ.get(name, str(default)).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _parse_hosts(raw: str) -> list[tuple[str, int]]:
+    """Parse ``"h1:26379,h2:26379"`` into ``[("h1", 26379), ("h2", 26379)]``."""
+    hosts: list[tuple[str, int]] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if ":" in item:
+            host, _, port = item.rpartition(":")
+            hosts.append((host, int(port)))
+        else:
+            hosts.append((item, 26379))
+    return hosts
+
+
+@dataclass
+class RedisConfig:
+    """Connection settings, populated from the pod's environment (HLD 5.2)."""
+
+    sentinel_hosts: list[tuple[str, int]] = field(default_factory=list)
+    master_name: str = "ufm"
+    host: str = "localhost"
+    port: int = 6379
+    password: Optional[str] = None
+    sentinel_password: Optional[str] = None
+    use_tls: bool = False
+    ca_cert: Optional[str] = None
+    socket_timeout: float = 5.0
+    socket_connect_timeout: float = 5.0
+
+    @classmethod
+    def from_env(cls) -> "RedisConfig":
+        sentinel_raw = os.environ.get("REDIS_SENTINEL_HOSTS", "")
+        return cls(
+            sentinel_hosts=_parse_hosts(sentinel_raw),
+            master_name=os.environ.get("REDIS_MASTER_NAME", "ufm"),
+            host=os.environ.get("REDIS_HOST", "localhost"),
+            port=int(os.environ.get("REDIS_PORT", "6379")),
+            password=os.environ.get("REDIS_PASSWORD") or None,
+            sentinel_password=os.environ.get("REDIS_SENTINEL_PASSWORD") or None,
+            use_tls=_env_bool("REDIS_USE_TLS", False),
+            ca_cert=os.environ.get("REDIS_CA_CERT") or None,
+            socket_timeout=float(os.environ.get("REDIS_SOCKET_TIMEOUT", "5.0")),
+            socket_connect_timeout=float(os.environ.get("REDIS_CONNECT_TIMEOUT", "5.0")),
+        )
+
+    def _common_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "socket_timeout": self.socket_timeout,
+            "socket_connect_timeout": self.socket_connect_timeout,
+        }
+        if self.password:
+            kwargs["password"] = self.password
+        if self.use_tls:
+            kwargs["ssl"] = True
+            if self.ca_cert:
+                kwargs["ssl_ca_certs"] = self.ca_cert
+        return kwargs
+
+
+def master_client(config: RedisConfig):
+    """Return a redis client bound to the current master.
+
+    When Sentinel hosts are configured the client resolves the master via
+    ``Sentinel.master_for`` so it follows failovers automatically; otherwise it
+    connects to the direct ``host:port`` endpoint.
+    """
+    import redis
+
+    common = config._common_kwargs()
+    if config.sentinel_hosts:
+        from redis.sentinel import Sentinel
+
+        sentinel_kwargs: dict[str, Any] = {}
+        if config.sentinel_password:
+            sentinel_kwargs["password"] = config.sentinel_password
+        if config.use_tls:
+            sentinel_kwargs["ssl"] = True
+            if config.ca_cert:
+                sentinel_kwargs["ssl_ca_certs"] = config.ca_cert
+        log.info(
+            "connecting via Sentinel %s (master=%s)",
+            config.sentinel_hosts,
+            config.master_name,
+        )
+        sentinel = Sentinel(
+            config.sentinel_hosts,
+            sentinel_kwargs=sentinel_kwargs,
+            **common,
+        )
+        return sentinel.master_for(config.master_name, **common)
+
+    log.info("connecting directly to %s:%d", config.host, config.port)
+    return redis.Redis(host=config.host, port=config.port, **common)

--- a/ufm-state-mirror/state_mirror/store.py
+++ b/ufm-state-mirror/state_mirror/store.py
@@ -1,0 +1,292 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Storage-backend abstraction for StateMirror (HLD 5.3.2 / 5.3.6).
+
+A *handler* knows *what* to capture from the filesystem and *when* (blob,
+atomic-blob, directory fan-out, sqlite online-backup). A ``Store`` knows *where*
+durable state lives and how to read it back. Splitting the two axes lets the
+same handlers run against different backends without change -- ConfigMaps
+(:class:`ConfigMapStore`, the default) or Redis (:class:`RedisStore`) -- so the
+choice of durable backing is a single, install-wide, swappable component.
+
+Each logical object is a body plus its verified metadata (:class:`wire.Meta`):
+the store persists the two atomically and, on read, verifies the body against
+the metadata (content hash / size / format version), failing closed on any
+mismatch. The interface is intentionally backend-neutral so the same handlers
+run unchanged against Redis or ConfigMaps.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Optional, Protocol
+
+from state_mirror import wire
+from state_mirror.k8s_errors import classify_k8s_error
+from state_mirror.wire import Meta
+
+log = logging.getLogger(__name__)
+
+
+class Store(ABC):
+    """A durable ``key -> (bytes, Meta)`` backend the handlers mirror to/from."""
+
+    @abstractmethod
+    def get(self, key: str) -> Optional[tuple[bytes, Meta]]:
+        """Read and verify a stored object.
+
+        Returns ``None`` when the key was never written (so the caller can fall
+        back to first-install bootstrap). Fails closed (raises) on a
+        present-but-corrupt object.
+        """
+
+    @abstractmethod
+    def get_meta(self, key: str) -> Optional[Meta]:
+        """Read just the metadata for ``key`` (``None`` if absent)."""
+
+    @abstractmethod
+    def put(self, key: str, body: bytes, meta: Meta) -> None:
+        """Atomically write a body together with its metadata."""
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Atomically delete a body together with its metadata."""
+
+    @abstractmethod
+    def list_keys(self, prefix: str) -> list[str]:
+        """Return every stored key (decoded) beginning with ``prefix``."""
+
+
+class RedisStore(Store):
+    """:class:`Store` backed by Redis/Valkey: one body key + one ``:meta`` key.
+
+    Wraps a duck-typed redis-py-style client (``get``/``set``/``delete``/
+    ``pipeline``/``keys``) and delegates the body+meta wire format and
+    fail-closed verification to :mod:`state_mirror.wire`.
+    """
+
+    def __init__(self, client):
+        self._client = client
+
+    def get(self, key: str) -> Optional[tuple[bytes, Meta]]:
+        return wire.read_and_verify(self._client, key)
+
+    def get_meta(self, key: str) -> Optional[Meta]:
+        raw = self._client.get(wire.meta_key(key))
+        return Meta.from_json(raw) if raw is not None else None
+
+    def put(self, key: str, body: bytes, meta: Meta) -> None:
+        wire.write_pair(self._client, key, body, meta)
+
+    def delete(self, key: str) -> None:
+        wire.delete_pair(self._client, key)
+
+    def list_keys(self, prefix: str) -> list[str]:
+        # SCAN (cursor-based), never KEYS: KEYS is O(N) and blocks the entire
+        # Redis server for the scan, which is unacceptable on a shared/large
+        # keyspace. ``scan_iter`` walks the keyspace incrementally without
+        # blocking other clients (called on directory restore and per full-scan).
+        keys = []
+        for key in self._client.scan_iter(match=prefix + "*"):
+            keys.append(key.decode() if isinstance(key, (bytes, bytearray)) else key)
+        return keys
+
+
+# --- ConfigMap backend (HLD 5.3.x) ---------------------------------------
+#
+# The default :class:`Store`: each key lives in the cluster's own state as one
+# ConfigMap rather than in Redis. The handlers and wire format are unchanged --
+# the backend is an install-wide, swappable component (HLD 5.2.3).
+
+# ConfigMaps are managed objects we own; this label lets ``list_keys`` enumerate
+# only ours, and the annotation carries the authoritative logical key (the
+# object name is a sanitized + hashed derivative and is not reversible).
+MANAGED_BY_LABEL = "app.kubernetes.io/managed-by"
+MANAGED_BY_VALUE = "state-mirror"
+KEY_ANNOTATION = "state-mirror.nvidia.com/key"
+
+# Field names within a ConfigMap object. The body is binary (base64 in the API,
+# so arbitrary file bytes survive); the metadata is UTF-8 JSON.
+BODY_FIELD = "body"
+META_FIELD = "meta"
+
+# Hard etcd object ceiling (~1 MiB). We fail closed *before* the apiserver would
+# (HLD 5.2.3): a ConfigMap-eligible file that grows past this must move to Redis
+# rather than silently stop mirroring.
+DEFAULT_MAX_OBJECT_BYTES = 1024 * 1024
+
+_NAME_SANITIZE_RE = re.compile(r"[^a-z0-9]+")
+_NAME_PREFIX = "state-mirror-"
+_DNS1123_MAX = 253
+_HASH_LEN = 10
+
+
+def configmap_name(key: str, prefix: str = _NAME_PREFIX) -> str:
+    """Map a logical key to a deterministic, DNS-1123-valid ConfigMap name.
+
+    Keys contain ``:`` and ``.`` which are not legal in an object name, so the
+    key is lowercased and squeezed to ``[a-z0-9-]`` and a short hash of the
+    *original* key is appended to keep names unique even after sanitization
+    collisions. The original key is preserved verbatim in an annotation.
+    """
+    base = _NAME_SANITIZE_RE.sub("-", key.lower()).strip("-")
+    digest = hashlib.sha1(key.encode("utf-8")).hexdigest()[:_HASH_LEN]
+    keep = _DNS1123_MAX - len(prefix) - len(digest) - 1
+    if len(base) > keep:
+        base = base[:keep].strip("-")
+    name = f"{prefix}{base}-{digest}" if base else f"{prefix}{digest}"
+    return name
+
+
+class ConfigMapApi(Protocol):
+    """Namespace-bound, dict-oriented view of the K8s ConfigMap API.
+
+    Kept deliberately tiny and free of kubernetes-client types so the store is
+    unit testable with an in-memory fake. The real adapter (which translates to
+    ``CoreV1Api`` and maps ``404 -> None``) lives in
+    :mod:`state_mirror.k8s_client` and imports the client lazily.
+    """
+
+    def read_cm(self, name: str) -> Optional[dict]: ...
+
+    def write_cm(
+        self,
+        name: str,
+        *,
+        labels: dict[str, str],
+        annotations: dict[str, str],
+        data: dict[str, str],
+        binary_data: dict[str, str],
+    ) -> None: ...
+
+    def delete_cm(self, name: str) -> None: ...
+
+    def list_cms(self, label_selector: str) -> list[dict]: ...
+
+
+class ConfigMapStore(Store):
+    """:class:`Store` backed by Kubernetes ConfigMaps: one object per key.
+
+    Each logical key maps to one ConfigMap carrying the file bytes in
+    ``binaryData[body]`` and the :class:`wire.Meta` JSON in ``data[meta]``;
+    writing the single object is therefore naturally atomic for that key.
+    Restore re-uses :func:`wire.verify_body`, so a ConfigMap-restored file is
+    validated byte-for-byte exactly like a Redis-restored one.
+    """
+
+    def __init__(self, api: ConfigMapApi, *, max_object_bytes: int = DEFAULT_MAX_OBJECT_BYTES):
+        self._api = api
+        self._max = max_object_bytes
+
+    def get(self, key: str) -> Optional[tuple[bytes, Meta]]:
+        cm = self._read(key)
+        if cm is None:
+            return None
+        meta = self._meta_of(cm)
+        if meta is None:
+            log.debug("%s present without metadata (bootstrap path)", key)
+            return None  # value-only object or never fully written
+        return wire.verify_body(self._body_of(cm), meta, key), meta
+
+    def get_meta(self, key: str) -> Optional[Meta]:
+        cm = self._read(key)
+        return self._meta_of(cm) if cm is not None else None
+
+    def put(self, key: str, body: bytes, meta: Meta) -> None:
+        b64 = base64.b64encode(body).decode("ascii")
+        data = {META_FIELD: meta.to_json().decode("utf-8")}
+        binary_data = {BODY_FIELD: b64}
+
+        # Intentionally conservative: we count the base64 length of the body,
+        # which is ~33% larger than the raw bytes etcd actually stores (base64 is
+        # only the REST/JSON representation of binaryData). This fails closed a bit
+        # early rather than risk an apiserver rejection near the ~1 MiB ceiling.
+        total = len(b64) + sum(len(k) + len(v) for k, v in data.items())
+        if total > self._max:
+            log.error("%s encoded object %d bytes exceeds limit %d", key, total, self._max)
+            raise wire.WireError(
+                f"{key}: encoded object {total} bytes exceeds ConfigMap limit {self._max}",
+                reason="toolarge",
+            )
+
+        try:
+            self._api.write_cm(
+                configmap_name(key),
+                labels={MANAGED_BY_LABEL: MANAGED_BY_VALUE},
+                annotations={KEY_ANNOTATION: key},
+                data=data,
+                binary_data=binary_data,
+            )
+        except Exception as exc:
+            reason = classify_k8s_error(exc)
+            log.error(
+                "configmap write failed for %s (%d bytes) [%s]: %s", key, len(body), reason, exc
+            )
+            raise wire.WireError(f"{key}: configmap write failed: {exc}", reason=reason) from exc
+        log.debug("wrote configmap for %s (%d bytes)", key, len(body))
+
+    def delete(self, key: str) -> None:
+        try:
+            self._api.delete_cm(configmap_name(key))
+        except Exception as exc:
+            reason = classify_k8s_error(exc)
+            if reason == "notfound":
+                return  # already gone -> idempotent
+            log.error("configmap delete failed for %s [%s]: %s", key, reason, exc)
+            raise wire.WireError(f"{key}: configmap delete failed: {exc}", reason=reason) from exc
+        log.info("deleted configmap for %s", key)
+
+    def list_keys(self, prefix: str) -> list[str]:
+        selector = f"{MANAGED_BY_LABEL}={MANAGED_BY_VALUE}"
+        try:
+            items = self._api.list_cms(selector)
+        except Exception as exc:
+            reason = classify_k8s_error(exc)
+            log.error("configmap list failed [%s]: %s", reason, exc)
+            raise wire.WireError(f"configmap list failed: {exc}", reason=reason) from exc
+        keys: list[str] = []
+        for cm in items:
+            key = (cm.get("annotations") or {}).get(KEY_ANNOTATION)
+            if key is not None and key.startswith(prefix):
+                keys.append(key)
+        return keys
+
+    # --- internals -------------------------------------------------------
+
+    def _read(self, key: str) -> Optional[dict]:
+        try:
+            return self._api.read_cm(configmap_name(key))
+        except Exception as exc:
+            reason = classify_k8s_error(exc)
+            if reason == "notfound":
+                return None
+            log.error("configmap read failed for %s [%s]: %s", key, reason, exc)
+            raise wire.WireError(f"{key}: configmap read failed: {exc}", reason=reason) from exc
+
+    @staticmethod
+    def _meta_of(cm: dict) -> Optional[Meta]:
+        raw = (cm.get("data") or {}).get(META_FIELD)
+        if raw is None:
+            return None
+        return Meta.from_json(raw.encode("utf-8") if isinstance(raw, str) else raw)
+
+    @staticmethod
+    def _body_of(cm: dict) -> Optional[bytes]:
+        encoded = (cm.get("binary_data") or {}).get(BODY_FIELD)
+        if encoded is None:
+            return None
+        return base64.b64decode(encoded)

--- a/ufm-state-mirror/tests/test_configmap_store.py
+++ b/ufm-state-mirror/tests/test_configmap_store.py
@@ -1,0 +1,236 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Unit tests for the ConfigMap-backed Store."""
+
+import base64
+import re
+
+import pytest
+
+from state_mirror import store as store_mod
+from state_mirror import wire
+from state_mirror.store import (
+    BODY_FIELD,
+    KEY_ANNOTATION,
+    MANAGED_BY_LABEL,
+    MANAGED_BY_VALUE,
+    ConfigMapStore,
+    configmap_name,
+)
+
+# DNS-1123 subdomain (what a ConfigMap name must satisfy).
+_DNS1123 = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+
+
+class _ApiException(Exception):
+    def __init__(self, status):
+        super().__init__(f"status={status}")
+        self.status = status
+
+
+class FakeConfigMapApi:
+    """In-memory CoreV1-ish ConfigMap API for unit tests."""
+
+    def __init__(self):
+        self.objs: dict[str, dict] = {}
+
+    def read_cm(self, name):
+        obj = self.objs.get(name)
+        if obj is None:
+            return None
+        return {
+            "name": name,
+            "annotations": dict(obj["annotations"]),
+            "data": dict(obj["data"]),
+            "binary_data": dict(obj["binary_data"]),
+        }
+
+    def write_cm(self, name, *, labels, annotations, data, binary_data):
+        self.objs[name] = {
+            "labels": dict(labels),
+            "annotations": dict(annotations),
+            "data": dict(data),
+            "binary_data": dict(binary_data),
+        }
+
+    def delete_cm(self, name):
+        self.objs.pop(name, None)
+
+    def list_cms(self, label_selector):
+        out = []
+        for name, obj in self.objs.items():
+            if obj["labels"].get(MANAGED_BY_LABEL) == MANAGED_BY_VALUE:
+                out.append(
+                    {
+                        "name": name,
+                        "annotations": dict(obj["annotations"]),
+                        "data": dict(obj["data"]),
+                        "binary_data": dict(obj["binary_data"]),
+                    }
+                )
+        return out
+
+
+@pytest.fixture
+def cm_api():
+    return FakeConfigMapApi()
+
+
+@pytest.fixture
+def cm_store(cm_api):
+    return ConfigMapStore(cm_api)
+
+
+def _put(store, key, body, handler="blob", ufm_version="7.0.1"):
+    meta = wire.build_meta(body, handler, ufm_version, "state-mirror:test")
+    store.put(key, body, meta)
+    return meta
+
+
+class TestRoundTrip:
+    def test_put_then_get(self, cm_store):
+        _put(cm_store, "ufm:cfg:plugins", b"payload")
+        body, meta = cm_store.get("ufm:cfg:plugins")
+        assert body == b"payload"
+        assert meta.size_bytes == 7
+        assert meta.handler == "blob"
+
+    def test_binary_safe(self, cm_store):
+        raw = bytes(range(256))  # non-UTF-8 / NUL bytes
+        _put(cm_store, "ufm:cfg:blob", raw)
+        body, _ = cm_store.get("ufm:cfg:blob")
+        assert body == raw
+
+    def test_get_meta(self, cm_store):
+        _put(cm_store, "ufm:cfg:plugins", b"abc")
+        meta = cm_store.get_meta("ufm:cfg:plugins")
+        assert meta is not None
+        assert meta.size_bytes == 3
+
+    def test_absent_key(self, cm_store):
+        assert cm_store.get("ufm:cfg:absent") is None
+        assert cm_store.get_meta("ufm:cfg:absent") is None
+
+    def test_overwrite(self, cm_store):
+        _put(cm_store, "ufm:cfg:plugins", b"v1")
+        _put(cm_store, "ufm:cfg:plugins", b"v2-longer")
+        body, meta = cm_store.get("ufm:cfg:plugins")
+        assert body == b"v2-longer"
+        assert meta.size_bytes == len(b"v2-longer")
+
+    def test_delete(self, cm_store):
+        _put(cm_store, "ufm:cfg:plugins", b"abc")
+        cm_store.delete("ufm:cfg:plugins")
+        assert cm_store.get("ufm:cfg:plugins") is None
+
+    def test_delete_absent_is_idempotent(self, cm_store):
+        cm_store.delete("ufm:cfg:never")  # must not raise
+
+
+class TestListKeys:
+    def test_prefix_filtering(self, cm_store):
+        _put(cm_store, "ufm:cfg:a", b"1")
+        _put(cm_store, "ufm:cfg:b", b"2")
+        _put(cm_store, "ufm:other:c", b"3")
+        assert sorted(cm_store.list_keys("ufm:cfg:")) == ["ufm:cfg:a", "ufm:cfg:b"]
+        assert cm_store.list_keys("ufm:other:") == ["ufm:other:c"]
+
+    def test_annotation_carries_original_key(self, cm_api, cm_store):
+        _put(cm_store, "ufm:cfg:plugins:child.json", b"x")
+        name = configmap_name("ufm:cfg:plugins:child.json")
+        assert cm_api.objs[name]["annotations"][KEY_ANNOTATION] == "ufm:cfg:plugins:child.json"
+
+
+class TestFailClosed:
+    def test_corrupt_body_raises(self, cm_api, cm_store):
+        _put(cm_store, "ufm:cfg:plugins", b"payload")
+        name = configmap_name("ufm:cfg:plugins")
+        cm_api.objs[name]["binary_data"][BODY_FIELD] = base64.b64encode(b"tampered").decode()
+        with pytest.raises(wire.WireError, match="content hash mismatch"):
+            cm_store.get("ufm:cfg:plugins")
+
+    def test_missing_body_raises(self, cm_api, cm_store):
+        _put(cm_store, "ufm:cfg:plugins", b"payload")
+        name = configmap_name("ufm:cfg:plugins")
+        cm_api.objs[name]["binary_data"].clear()
+        with pytest.raises(wire.WireError, match="body key missing"):
+            cm_store.get("ufm:cfg:plugins")
+
+    def test_ceiling_fails_closed(self, cm_api):
+        store = ConfigMapStore(cm_api, max_object_bytes=128)
+        meta = wire.build_meta(b"x" * 512, "blob", "7.0.1", "state-mirror:test")
+        with pytest.raises(wire.WireError, match="exceeds ConfigMap limit") as ei:
+            store.put("ufm:cfg:big", b"x" * 512, meta)
+        assert ei.value.reason == "toolarge"
+        # Nothing was written.
+        assert cm_api.objs == {}
+
+
+class TestErrorClassification:
+    def test_read_404_returns_none(self, cm_store, cm_api):
+        def boom(_name):
+            raise _ApiException(404)
+
+        cm_api.read_cm = boom
+        assert cm_store.get("ufm:cfg:plugins") is None
+
+    def test_write_403_raises_forbidden(self, cm_store, cm_api):
+        def boom(*_a, **_k):
+            raise _ApiException(403)
+
+        cm_api.write_cm = boom
+        meta = wire.build_meta(b"x", "blob", "7.0.1", "state-mirror:test")
+        with pytest.raises(wire.WireError) as ei:
+            cm_store.put("ufm:cfg:plugins", b"x", meta)
+        assert ei.value.reason == "forbidden"
+
+    def test_read_409_propagates_as_wire_error(self, cm_store, cm_api):
+        def boom(_name):
+            raise _ApiException(409)
+
+        cm_api.read_cm = boom
+        with pytest.raises(wire.WireError) as ei:
+            cm_store.get("ufm:cfg:plugins")
+        assert ei.value.reason == "conflict"
+
+
+class TestConfigMapName:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "ufm:opensm:opensm.conf",
+            "ufm:cfg:plugins:child.json",
+            "UFM:Mixed:Case",
+            "a",
+            "x" * 400,
+        ],
+    )
+    def test_name_is_dns1123(self, key):
+        name = configmap_name(key)
+        assert len(name) <= 253
+        assert _DNS1123.match(name), name
+
+    def test_name_is_deterministic(self):
+        assert configmap_name("ufm:cfg:a") == configmap_name("ufm:cfg:a")
+
+    def test_distinct_keys_distinct_names(self):
+        # Keys that sanitize to the same base must still differ (hash suffix).
+        assert configmap_name("ufm:cfg:a") != configmap_name("ufm.cfg.a")
+
+
+def test_protocol_symbols_exported():
+    # Guard against accidental rename of the public field/label constants the
+    # consumer Helm wiring and tests depend on.
+    assert store_mod.MANAGED_BY_VALUE == "state-mirror"
+    assert store_mod.BODY_FIELD == "body"
+    assert store_mod.META_FIELD == "meta"


### PR DESCRIPTION
Second slice of the StateMirror sidecar (stacked on PR 1/4).

Adds the backend-neutral persistence layer:
- store: the Store port plus RedisStore and ConfigMapStore (one ConfigMap per
  key, binaryData body + meta field, fail-closed ~1 MiB ceiling, shared
  wire.verify_body integrity check).
- redis_client / k8s_client: lazy connection adapters (kubernetes and redis
  imported lazily so a deployment using only one backend needs only its deps).

Handlers and the routing that picks a backend follow in PR 3/4.
Tests: ConfigMapStore covered; ruff clean.

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug, please reference. For
Bug fixes why and what can be merged in a single item._

## How ?
_It is optional, but for complex PRs please provide information about the design,
architecture, approach, etc._

## Testing ?
_How was this feature tested? Did you add unit tests? Did you add E2E tests?_

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
