### PR TITLE
state-mirror (3/4): handlers + routing

### DIFF
--- a/ufm-state-mirror/state_mirror/backends.py
+++ b/ufm-state-mirror/state_mirror/backends.py
@@ -1,0 +1,101 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Select and build the sidecar's single ``Store`` backend (HLD 5.2.3, 5.3.11).
+
+Exactly **one** backend is chosen at install time and used for the entire
+sidecar -- there is no per-file routing. The operator sets it once (Helm value
+surfaced as the ``STATE_MIRROR_BACKEND`` env var), the init container and the
+runtime sidecar both build that one ``Store`` at startup and hand it to every
+handler. The default is ``configmap`` (etcd-backed, no external store to run);
+``redis`` is the alternative for deployments whose state does not fit the
+ConfigMap ~1 MiB object cap.
+
+The backend constructors are injected, keeping selection unit-testable without
+the redis-py or kubernetes dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from enum import Enum
+from typing import Callable
+
+from state_mirror.store import Store
+
+log = logging.getLogger(__name__)
+
+
+class Backend(str, Enum):
+    """The durable backend the sidecar mirrors to (install-wide, HLD 5.2.3)."""
+
+    CONFIGMAP = "configmap"
+    REDIS = "redis"
+
+
+# ConfigMap is the default: no external store to run, state lives in the
+# cluster's own etcd (HLD 5.2.3). Redis is opted into for large/high-churn state.
+DEFAULT_BACKEND = Backend.CONFIGMAP
+
+BACKEND_ENV = "STATE_MIRROR_BACKEND"
+
+
+def backend_from_env() -> Backend:
+    """Resolve the install-wide backend from ``STATE_MIRROR_BACKEND``.
+
+    Defaults to :data:`DEFAULT_BACKEND` (configmap). Raises ``ValueError`` on an
+    unrecognized value so a misconfigured install fails closed at startup rather
+    than silently mirroring to the wrong place.
+    """
+    raw = os.environ.get(BACKEND_ENV, DEFAULT_BACKEND.value).strip().lower()
+    try:
+        return Backend(raw)
+    except ValueError:
+        allowed = ", ".join(b.value for b in Backend)
+        raise ValueError(f"invalid {BACKEND_ENV} '{raw}' (allowed: {allowed})") from None
+
+
+def default_redis_store() -> Store:
+    """Build the production Redis store from the pod environment (HLD 8.8)."""
+    from state_mirror.redis_client import RedisConfig, master_client
+    from state_mirror.store import RedisStore
+
+    return RedisStore(master_client(RedisConfig.from_env()))
+
+
+def default_configmap_store() -> Store:
+    """Build the production ConfigMap store via in-cluster config (HLD 5.3.x).
+
+    Imported lazily so a Redis-backend deployment never loads the kubernetes
+    client (and a unit test never needs it installed).
+    """
+    from state_mirror.k8s_client import configmap_api_from_env
+    from state_mirror.store import ConfigMapStore
+
+    return ConfigMapStore(configmap_api_from_env())
+
+
+def build_store(
+    backend: Backend,
+    *,
+    redis_factory: Callable[[], Store] = default_redis_store,
+    configmap_factory: Callable[[], Store] = default_configmap_store,
+) -> Store:
+    """Construct the single ``Store`` for the chosen install-wide backend."""
+    if backend is Backend.CONFIGMAP:
+        log.info("storage backend: configmap (etcd-backed)")
+        return configmap_factory()
+    if backend is Backend.REDIS:
+        log.info("storage backend: redis (BYO)")
+        return redis_factory()
+    raise ValueError(f"unsupported backend: {backend!r}")  # pragma: no cover

--- a/ufm-state-mirror/state_mirror/handlers/__init__.py
+++ b/ufm-state-mirror/state_mirror/handlers/__init__.py
@@ -1,0 +1,50 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""StateMirror per-handler logic (HLD 5.3.2)."""
+
+from state_mirror.classifier import Entry, Handler
+from state_mirror.handlers.atomic_blob import AtomicBlobHandler
+from state_mirror.handlers.base import BaseHandler
+from state_mirror.handlers.blob import BlobHandler
+from state_mirror.handlers.directory import DirectoryHandler
+from state_mirror.handlers.sqlite import SqliteHandler
+
+_REGISTRY = {
+    Handler.BLOB: BlobHandler,
+    Handler.ATOMIC_BLOB: AtomicBlobHandler,
+    Handler.DIRECTORY: DirectoryHandler,
+    Handler.SQLITE: SqliteHandler,
+}
+
+
+def make_handler(entry: Entry, store, ufm_version: str, written_by: str) -> BaseHandler:
+    """Instantiate the handler class for a classifier entry over ``store``.
+
+    A single install-wide :class:`~state_mirror.store.Store` backs every entry;
+    the backend is chosen once at install time (HLD 5.2.3), not per file.
+    """
+    try:
+        cls = _REGISTRY[entry.handler]
+    except KeyError:  # pragma: no cover - guarded by classifier validation
+        raise ValueError(f"no handler registered for {entry.handler}") from None
+    return cls(entry, store, ufm_version, written_by)
+
+
+__all__ = [
+    "BaseHandler",
+    "BlobHandler",
+    "AtomicBlobHandler",
+    "DirectoryHandler",
+    "SqliteHandler",
+    "make_handler",
+]

--- a/ufm-state-mirror/state_mirror/handlers/atomic_blob.py
+++ b/ufm-state-mirror/state_mirror/handlers/atomic_blob.py
@@ -1,0 +1,27 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Atomic-blob handler (HLD 5.3.2).
+
+For writers that use the write-tmp-then-rename pattern (e.g. OpenSM): the
+rename surfaces to watchdog as a move event, and the file is already complete
+when we read it. Behavior is identical to a blob today; the distinct class
+documents the writer contract and leaves room for move-specific tuning.
+"""
+
+from __future__ import annotations
+
+from state_mirror.handlers.blob import BlobHandler
+
+
+class AtomicBlobHandler(BlobHandler):
+    pass

--- a/ufm-state-mirror/state_mirror/handlers/base.py
+++ b/ufm-state-mirror/state_mirror/handlers/base.py
@@ -104,7 +104,16 @@ class BaseHandler:
         return sent
 
     def on_delete(self) -> None:
-        """Propagate a local delete to the store (HLD 5.3.9)."""
+        """Propagate a local delete to the store (HLD 5.3.9).
+
+        Deletes are NOT durable across restarts for entries with
+        ``baseline=image`` or ``baseline=empty``: dropping the key means the next
+        startup finds no stored object, :meth:`restore` returns ``False``, and
+        ``bootstrap`` re-seeds the file from its baseline -- so a deliberately
+        deleted file reappears. This is consistent with the "backend wins on
+        ambiguity" policy; making deletes survive a restore would require writing
+        a tombstone key (future work).
+        """
         log.info("on_delete: dropping %s from store", self.entry.redis_key)
         self.store.delete(self.entry.redis_key)
 
@@ -221,9 +230,7 @@ class BaseHandler:
         try:
             os.chown(path, prev.st_uid, prev.st_gid)
         except OSError as exc:
-            log.warning(
-                "chown of %s to %d:%d failed: %s", path, prev.st_uid, prev.st_gid, exc
-            )
+            log.warning("chown of %s to %d:%d failed: %s", path, prev.st_uid, prev.st_gid, exc)
 
     @staticmethod
     def _restore_one(store: Store, key: str, dest_path: str) -> Optional[wire.Meta]:

--- a/ufm-state-mirror/state_mirror/handlers/base.py
+++ b/ufm-state-mirror/state_mirror/handlers/base.py
@@ -1,0 +1,235 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Base handler: shared restore/mirror/delete logic over a pluggable store.
+
+A handler is the per-path policy object (HLD 5.3.2): it knows how to read a
+classified file, push it to the store (only when changed), restore it on
+startup, seed a first-install baseline, and propagate deletes. Subclasses
+specialize the read/snapshot behavior (atomic blob, directory fan-out, sqlite
+online backup). *Where* the bytes are persisted is the store's concern, not the
+handler's (see :mod:`state_mirror.store`).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from typing import Optional
+
+from state_mirror import wire
+from state_mirror.classifier import Baseline, Entry
+from state_mirror.store import Store
+
+log = logging.getLogger(__name__)
+
+
+class BaseHandler:
+    def __init__(self, entry: Entry, store: Store, ufm_version: str, written_by: str):
+        self.entry = entry
+        self.store = store
+        self.ufm_version = ufm_version
+        self.written_by = written_by
+
+    def restore(self) -> bool:
+        """Materialize this entry's file(s) from the store.
+
+        Returns True if a stored object was restored, False if the store has no
+        object yet (first install -> caller should bootstrap).
+        """
+        result = self.store.get(self.entry.redis_key)
+        if result is None:
+            log.debug("restore: no stored object for %s", self.entry.path)
+            return False
+        body, _meta = result
+        self._write_file(self.entry.path, body)
+        log.info(
+            "restore: wrote %s (%d bytes) from %s", self.entry.path, len(body), self.entry.redis_key
+        )
+        return True
+
+    def bootstrap(self) -> None:
+        """First-install: seed the file from its baseline and push to Redis."""
+        if self.entry.baseline is Baseline.SKIP:
+            log.debug("bootstrap: %s baseline=skip, nothing to seed", self.entry.path)
+            return
+        if self.entry.baseline is Baseline.EMPTY:
+            body = b""
+        elif self.entry.baseline is Baseline.IMAGE:
+            try:
+                with open(self.entry.baseline_path, "rb") as f:
+                    body = f.read()
+            except OSError as exc:
+                log.error("bootstrap: cannot read baseline %s: %s", self.entry.baseline_path, exc)
+                raise
+        else:
+            raise ValueError(f"unknown baseline {self.entry.baseline}")
+        self._write_file(self.entry.path, body)
+        self._push(self.entry.redis_key, body)
+        log.info(
+            "bootstrap: seeded %s (%d bytes, baseline=%s)",
+            self.entry.path,
+            len(body),
+            self.entry.baseline.value,
+        )
+
+    def mirror(self) -> bool:
+        """Push the current file to Redis if it differs. Returns True if sent.
+
+        Idempotent: compares the stored content hash before writing so an
+        unchanged file is a cheap no-op.
+        """
+        if not os.path.exists(self.entry.path):
+            log.debug("mirror: %s does not exist yet, skipping", self.entry.path)
+            return False
+        body = self._read_file(self.entry.path)
+        sent = self._push_if_changed(self.entry.redis_key, body)
+        if sent:
+            log.info(
+                "mirror: shipped %s (%d bytes) -> %s",
+                self.entry.path,
+                len(body),
+                self.entry.redis_key,
+            )
+        return sent
+
+    def on_delete(self) -> None:
+        """Propagate a local delete to the store (HLD 5.3.9)."""
+        log.info("on_delete: dropping %s from store", self.entry.redis_key)
+        self.store.delete(self.entry.redis_key)
+
+    def key_for_fs_path(self, fs_path: str) -> str:
+        """Store key for a deleted local path. Single-file handlers ignore the
+        path and use their one key; the directory handler derives a per-child key.
+        """
+        return self.entry.redis_key
+
+    def drift_keys(self) -> list[str]:
+        """Keys present in the backend but whose local file is gone (HLD 5.3.7).
+
+        Reports drift without deleting -- the caller surfaces it via
+        ``state_mirror_unexpected_delete_total`` and the backend object wins on
+        ambiguity (the next restore re-materializes the file). An empty list means
+        no drift.
+        """
+        if os.path.exists(self.entry.path):
+            return []
+        if self.store.get_meta(self.entry.redis_key) is None:
+            return []
+        return [self.entry.redis_key]
+
+    def _push_if_changed(self, key: str, body: bytes) -> bool:
+        meta = self.store.get_meta(key)
+        if meta is not None and meta.content_hash == wire.content_hash(body):
+            return False
+        self._push(key, body)
+        return True
+
+    def _push(self, key: str, body: bytes) -> None:
+        meta = wire.build_meta(
+            body,
+            handler=self.entry.handler.value,
+            ufm_version=self.ufm_version,
+            written_by=self.written_by,
+        )
+        self.store.put(key, body, meta)
+
+    @staticmethod
+    def _read_file(path: str) -> bytes:
+        try:
+            with open(path, "rb") as f:
+                return f.read()
+        except OSError as exc:
+            log.error("read of %s failed: %s", path, exc)
+            raise
+
+    @staticmethod
+    def _write_file(path: str, body: bytes) -> None:
+        """Write atomically (tmp + os.replace) so readers never see a torn file.
+
+        The tmp+rename creates a *new* inode owned by the writer. During the
+        root-run restore init this would strip the destination's original owner
+        (e.g. ``conf/*`` and ``sqlite/*`` are ufmapp 731:731), leaving UFM unable
+        to write its own state after a restart. So if the destination already
+        exists we capture its uid/gid/mode first and re-apply them after the
+        rename (HLD: restore must be transparent to the consumer).
+        """
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        prev = BaseHandler._stat_or_none(path)
+        tmp = path + ".statemirror.tmp"
+        try:
+            with open(tmp, "wb") as f:
+                f.write(body)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, path)
+        except OSError as exc:
+            log.error("atomic write of %s failed: %s", path, exc)
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            raise
+        if prev is not None:
+            BaseHandler._reapply_identity(path, prev)
+
+    @staticmethod
+    def _stat_or_none(path: str) -> Optional[os.stat_result]:
+        try:
+            return os.stat(path)
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            log.debug("stat of %s before restore failed: %s", path, exc)
+            return None
+
+    @staticmethod
+    def _reapply_identity(path: str, prev: os.stat_result) -> None:
+        """Restore the pre-existing owner/group/mode onto the freshly written file.
+
+        Best-effort and guarded: ``chown`` needs root, so when not effectively
+        root (unit tests, or the non-root sidecar) it is skipped and logged at
+        debug rather than raising -- the restore init runs as root, which is where
+        it matters. ``chmod`` is attempted regardless (the writer owns the new
+        inode) and failures are non-fatal.
+        """
+        mode = stat.S_IMODE(prev.st_mode)
+        try:
+            os.chmod(path, mode)
+        except OSError as exc:
+            log.debug("chmod of %s to %o failed: %s", path, mode, exc)
+        euid = os.geteuid() if hasattr(os, "geteuid") else -1
+        if euid != 0:
+            log.debug(
+                "not root (euid=%s); leaving %s owned by writer (was %d:%d)",
+                euid,
+                path,
+                prev.st_uid,
+                prev.st_gid,
+            )
+            return
+        try:
+            os.chown(path, prev.st_uid, prev.st_gid)
+        except OSError as exc:
+            log.warning(
+                "chown of %s to %d:%d failed: %s", path, prev.st_uid, prev.st_gid, exc
+            )
+
+    @staticmethod
+    def _restore_one(store: Store, key: str, dest_path: str) -> Optional[wire.Meta]:
+        result = store.get(key)
+        if result is None:
+            return None
+        body, meta = result
+        BaseHandler._write_file(dest_path, body)
+        return meta

--- a/ufm-state-mirror/state_mirror/handlers/blob.py
+++ b/ufm-state-mirror/state_mirror/handlers/blob.py
@@ -1,0 +1,25 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Blob handler: a single file mirrored as one Redis key (HLD 5.3.2).
+
+Runtime trigger is watchdog's close-write event. The base class already does
+read -> hash-compare -> atomic write, so a plain blob needs no extra behavior.
+"""
+
+from __future__ import annotations
+
+from state_mirror.handlers.base import BaseHandler
+
+
+class BlobHandler(BaseHandler):
+    pass

--- a/ufm-state-mirror/state_mirror/handlers/directory.py
+++ b/ufm-state-mirror/state_mirror/handlers/directory.py
@@ -43,10 +43,13 @@ class DirectoryHandler(BaseHandler):
                     full = os.path.join(dirpath, name)
                     yield os.path.relpath(full, root), full
         else:
-            for name in sorted(os.listdir(root)):
-                full = os.path.join(root, name)
-                if os.path.isfile(full):
-                    yield name, full
+            # scandir reuses the stat already done by the OS (one syscall per
+            # entry instead of listdir + isfile). follow_symlinks=True keeps the
+            # prior os.path.isfile semantics: a symlink to a file still counts.
+            with os.scandir(root) as it:
+                for de in sorted(it, key=lambda e: e.name):
+                    if de.is_file(follow_symlinks=True):
+                        yield de.name, de.path
 
     def _iter_redis_relpaths(self):
         prefix = self.entry.redis_key_prefix
@@ -78,14 +81,19 @@ class DirectoryHandler(BaseHandler):
     def mirror(self) -> bool:
         sent_any = False
         for relpath, full in self._iter_local_files():
+            # A local read error for one child (e.g. it vanished mid-scan) is
+            # skipped so the rest of the tree still mirrors. A backend error
+            # (WireError) is NOT swallowed -- it propagates so the caller records
+            # the outage via record_store_down instead of seeing a healthy run.
             try:
                 body = self._read_file(full)
-                key = self._key_for_rel(relpath)
-                if self._push_if_changed(key, body):
-                    log.info("mirror: shipped %s -> %s", full, key)
-                    sent_any = True
-            except Exception:
-                log.exception("mirror: failed to ship child %s; continuing", relpath)
+            except OSError:
+                log.exception("mirror: cannot read child %s; skipping", full)
+                continue
+            key = self._key_for_rel(relpath)
+            if self._push_if_changed(key, body):
+                log.info("mirror: shipped %s -> %s", full, key)
+                sent_any = True
         return sent_any
 
     def on_delete_child(self, relpath: str) -> None:

--- a/ufm-state-mirror/state_mirror/handlers/directory.py
+++ b/ufm-state-mirror/state_mirror/handlers/directory.py
@@ -1,0 +1,115 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Directory handler: mirror every child file under a watched directory, one
+Redis key per file derived from a key prefix + relative path (HLD 5.3.2).
+
+Used for config trees (e.g. plugin conf directories) where the set of files is
+not known in advance. Restore enumerates the Redis keys under the prefix and
+recreates the tree; per-child deletes are propagated individually.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from state_mirror import wire
+from state_mirror.handlers.base import BaseHandler
+
+log = logging.getLogger(__name__)
+
+
+class DirectoryHandler(BaseHandler):
+    def _key_for_rel(self, relpath: str) -> str:
+        return self.entry.redis_key_prefix + relpath
+
+    def _iter_local_files(self):
+        root = self.entry.path
+        if not os.path.isdir(root):
+            return
+        if self.entry.recursive:
+            for dirpath, _dirs, files in os.walk(root):
+                for name in sorted(files):
+                    full = os.path.join(dirpath, name)
+                    yield os.path.relpath(full, root), full
+        else:
+            for name in sorted(os.listdir(root)):
+                full = os.path.join(root, name)
+                if os.path.isfile(full):
+                    yield name, full
+
+    def _iter_redis_relpaths(self):
+        prefix = self.entry.redis_key_prefix
+        for key in self.store.list_keys(prefix):
+            if key.endswith(wire.META_SUFFIX):
+                continue
+            yield key[len(prefix) :]
+
+    def restore(self) -> bool:
+        count = 0
+        root = os.path.realpath(self.entry.path)
+        for relpath in self._iter_redis_relpaths():
+            dest = os.path.join(self.entry.path, relpath)
+            # Restore is the fail-closed boundary: a corrupt/hostile backend key
+            # containing ``..`` must not let us write outside the entry root.
+            if not self._within(root, dest):
+                log.error("restore: skipping child key with out-of-root path %r", relpath)
+                continue
+            if self._restore_one(self.store, self._key_for_rel(relpath), dest) is not None:
+                count += 1
+        log.info("restore: %s restored %d child file(s)", self.entry.path, count)
+        return count > 0
+
+    @staticmethod
+    def _within(root: str, dest: str) -> bool:
+        real = os.path.realpath(dest)
+        return real == root or real.startswith(root + os.sep)
+
+    def mirror(self) -> bool:
+        sent_any = False
+        for relpath, full in self._iter_local_files():
+            try:
+                body = self._read_file(full)
+                key = self._key_for_rel(relpath)
+                if self._push_if_changed(key, body):
+                    log.info("mirror: shipped %s -> %s", full, key)
+                    sent_any = True
+            except Exception:
+                log.exception("mirror: failed to ship child %s; continuing", relpath)
+        return sent_any
+
+    def on_delete_child(self, relpath: str) -> None:
+        log.info("on_delete_child: dropping %s", relpath)
+        self.store.delete(self._key_for_rel(relpath))
+
+    def on_delete(self) -> None:
+        for relpath in list(self._iter_redis_relpaths()):
+            self.on_delete_child(relpath)
+
+    def key_for_fs_path(self, fs_path: str) -> str:
+        """Per-child store key for a deleted file under the watched directory."""
+        return self._key_for_rel(os.path.relpath(fs_path, self.entry.path))
+
+    def drift_keys(self) -> list[str]:
+        """Per-child orphans: backend children with no local file (HLD 5.3.7)."""
+        local = {relpath for relpath, _full in self._iter_local_files()}
+        return [
+            self._key_for_rel(relpath)
+            for relpath in self._iter_redis_relpaths()
+            if relpath not in local
+        ]
+
+    def bootstrap(self) -> None:
+        # Directories have no single-file baseline; first-install is whatever
+        # the image ships, mirrored on the first full scan.
+        pass

--- a/ufm-state-mirror/state_mirror/handlers/sqlite.py
+++ b/ufm-state-mirror/state_mirror/handlers/sqlite.py
@@ -182,6 +182,11 @@ class SqliteHandler(BaseHandler):
     def restore(self) -> bool:
         """Restore the snapshot and verify integrity.
 
+        The stored object is integrity-checked on a throwaway temp copy *before*
+        the live DB is touched, so a corrupt backend snapshot can never destroy
+        the installer-seeded DB: the check raises and the on-disk file is left
+        intact. Only once it verifies do we write it into place via
+        :meth:`_write_file`, which preserves the DB's original uid/gid/mode.
         Fails closed (raises) on an integrity-check failure so the init
         container never lets UFM start on a corrupt DB.
         """
@@ -190,8 +195,8 @@ class SqliteHandler(BaseHandler):
             log.debug("restore: no stored object for %s", self.entry.path)
             return False
         body, _meta = result
+        self._verify_snapshot(body)
         self._write_file(self.entry.path, body)
-        self.integrity_check(self.entry.path)
         log.info(
             "restore: wrote %s (%d bytes) from %s",
             self.entry.path,
@@ -199,3 +204,22 @@ class SqliteHandler(BaseHandler):
             self.entry.redis_key,
         )
         return True
+
+    def _verify_snapshot(self, body: bytes) -> None:
+        """Integrity-check ``body`` as a SQLite DB without touching the live file.
+
+        Writes to a throwaway temp (cleaned up in all cases) and runs
+        ``integrity_check`` there; raises on failure so the caller never replaces
+        the live DB with a bad snapshot.
+        """
+        fd, tmp = tempfile.mkstemp(prefix="statemirror-restore-", suffix=".db")
+        os.close(fd)
+        try:
+            with open(tmp, "wb") as f:
+                f.write(body)
+                f.flush()
+                os.fsync(f.fileno())
+            self.integrity_check(tmp)
+        finally:
+            for suffix in ("", "-wal", "-shm"):
+                self._safe_unlink(tmp + suffix)

--- a/ufm-state-mirror/state_mirror/handlers/sqlite.py
+++ b/ufm-state-mirror/state_mirror/handlers/sqlite.py
@@ -1,0 +1,201 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""SQLite handler (HLD 5.3.4 / Phase 5): snapshot-only.
+
+Naive file-level mirroring of a live SQLite DB can capture a mid-transaction
+state, so we never copy the file bytes directly. Instead we take a consistent
+copy with the SQLite online backup API and mirror the whole DB as one blob,
+only when the DB actually changed. This is the right fit for UFM's DBs, which
+are small (gv.db is typically < 50 MiB) and comfortably under the backend's
+object size limits.
+
+There is no WAL-shipping: every cycle ships a full, consistent snapshot rather
+than a base + incremental ``-wal`` segment (HLD 5.5). The handler never changes
+a DB's journal mode -- it only reads.
+
+Change detection: a counter-only poll would miss live writes on a WAL-mode DB,
+because in WAL mode a write lands in ``-wal`` and does NOT bump the main DB
+header's change counter until a checkpoint. ``signature()`` therefore combines
+the header change counter with the ``-wal`` file's size and mtime, so it is
+correct whether the DB is in rollback-journal or WAL mode.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import tempfile
+import time
+
+from state_mirror.handlers.base import BaseHandler
+
+log = logging.getLogger(__name__)
+
+# SQLite DB header layout: the 4-byte big-endian file change counter lives at
+# offset 24 (https://www.sqlite.org/fileformat.html#file_change_counter).
+_CHANGE_COUNTER_OFFSET = 24
+_CHANGE_COUNTER_SIZE = 4
+_HEADER_MIN_SIZE = _CHANGE_COUNTER_OFFSET + _CHANGE_COUNTER_SIZE
+
+
+class SqliteHandler(BaseHandler):
+    # Wall-clock (seconds) of the most recent online-backup snapshot, surfaced as
+    # state_mirror_snapshot_duration_seconds{db=...} for the Phase 5 / R2 gate
+    # ("snapshot-duration headroom under load"). None when the last mirror() did
+    # not take a snapshot (so a stale value is never re-published).
+    last_snapshot_seconds: float | None = None
+    # Signature of the DB the last time we shipped (or confirmed in-sync) it, so
+    # mirror() can skip the expensive online-backup snapshot when nothing changed
+    # -- the periodic full scan calls mirror() on every entry, and a counter-only
+    # idle DB must not be re-snapshotted every cycle.
+    _last_shipped_sig: tuple | None = None
+
+    # ---- change detection --------------------------------------------------
+    @staticmethod
+    def _wal_path(db_path: str) -> str:
+        return db_path + "-wal"
+
+    @staticmethod
+    def read_change_counter(path: str) -> int:
+        """Return the DB header's file_change_counter (0 if unreadable)."""
+        try:
+            with open(path, "rb") as f:
+                header = f.read(_HEADER_MIN_SIZE)
+        except FileNotFoundError:
+            return 0
+        except OSError as exc:
+            log.warning("change-counter read of %s failed: %s; treating as unchanged", path, exc)
+            return 0
+        if len(header) < _HEADER_MIN_SIZE:
+            return 0
+        return int.from_bytes(header[_CHANGE_COUNTER_OFFSET:_HEADER_MIN_SIZE], "big")
+
+    def signature(self) -> tuple[int, int, int]:
+        """A cheap change fingerprint: (header change counter, wal size, wal mtime).
+
+        Includes the ``-wal`` file because WAL-mode writes don't bump the header
+        change counter until a checkpoint.
+        """
+        cc = self.read_change_counter(self.entry.path)
+        try:
+            st = os.stat(self._wal_path(self.entry.path))
+            return (cc, st.st_size, st.st_mtime_ns)
+        except OSError:
+            return (cc, -1, -1)
+
+    @staticmethod
+    def integrity_check(path: str) -> None:
+        """Run PRAGMA integrity_check; raise sqlite3.DatabaseError if not 'ok'."""
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=30.0)
+        try:
+            row = conn.execute("PRAGMA integrity_check;").fetchone()
+        finally:
+            conn.close()
+        result = row[0] if row else None
+        if result != "ok":
+            raise sqlite3.DatabaseError(f"integrity_check failed for {path}: {result!r}")
+
+    # ---- snapshot (online backup) -----------------------------------------
+    def snapshot_bytes(self) -> bytes:
+        """Consistent copy of the live DB via the SQLite online backup API.
+
+        Records the wall-clock of the backup in :attr:`last_snapshot_seconds` so
+        the loop can publish ``state_mirror_snapshot_duration_seconds`` (HLD 5.3.4).
+        """
+        fd, tmp = tempfile.mkstemp(prefix="statemirror-sqlite-", suffix=".db")
+        os.close(fd)
+        try:
+            started = time.perf_counter()
+            src = sqlite3.connect(f"file:{self.entry.path}?mode=ro", uri=True, timeout=30.0)
+            try:
+                dst = sqlite3.connect(tmp, timeout=30.0)
+                try:
+                    src.backup(dst)
+                finally:
+                    dst.close()
+            finally:
+                src.close()
+            self.last_snapshot_seconds = time.perf_counter() - started
+            with open(tmp, "rb") as f:
+                return f.read()
+        except sqlite3.Error as exc:
+            log.error("sqlite snapshot of %s failed: %s", self.entry.path, exc)
+            raise
+        finally:
+            for suffix in ("", "-wal", "-shm"):
+                self._safe_unlink(tmp + suffix)
+
+    @staticmethod
+    def _safe_unlink(path: str) -> None:
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+        except OSError:
+            log.warning("could not remove temp file %s", path)
+
+    # ---- mirror ------------------------------------------------------------
+    def mirror(self) -> bool:
+        # Each mirror() reports the snapshot cost only if it actually snapshots.
+        self.last_snapshot_seconds = None
+        if not os.path.exists(self.entry.path):
+            log.debug("mirror: sqlite db %s does not exist yet, skipping", self.entry.path)
+            return False
+        try:
+            size = os.path.getsize(self.entry.path)
+        except OSError as exc:
+            log.warning("mirror: cannot stat %s: %s; skipping", self.entry.path, exc)
+            return False
+        if size == 0:
+            log.debug("mirror: sqlite db %s is empty, skipping", self.entry.path)
+            return False
+        # Cheap change fingerprint first: skip the O(DB-size) online backup when
+        # the DB is unchanged since the last successful ship (HLD 5.3.4).
+        sig = self.signature()
+        if sig == self._last_shipped_sig:
+            return False
+        body = self.snapshot_bytes()
+        sent = self._push_if_changed(self.entry.redis_key, body)
+        # The snapshot at this signature is now persisted (or byte-identical to
+        # what the backend already holds), so don't snapshot again until it moves.
+        self._last_shipped_sig = sig
+        if sent:
+            log.info(
+                "mirror: shipped sqlite snapshot %s (%d bytes) -> %s",
+                self.entry.path,
+                len(body),
+                self.entry.redis_key,
+            )
+        return sent
+
+    # ---- restore -----------------------------------------------------------
+    def restore(self) -> bool:
+        """Restore the snapshot and verify integrity.
+
+        Fails closed (raises) on an integrity-check failure so the init
+        container never lets UFM start on a corrupt DB.
+        """
+        result = self.store.get(self.entry.redis_key)
+        if result is None:
+            log.debug("restore: no stored object for %s", self.entry.path)
+            return False
+        body, _meta = result
+        self._write_file(self.entry.path, body)
+        self.integrity_check(self.entry.path)
+        log.info(
+            "restore: wrote %s (%d bytes) from %s",
+            self.entry.path,
+            len(body),
+            self.entry.redis_key,
+        )
+        return True

--- a/ufm-state-mirror/tests/test_backends.py
+++ b/ufm-state-mirror/tests/test_backends.py
@@ -1,0 +1,90 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Unit tests for install-wide backend selection (backend_from_env + build_store)."""
+
+import pytest
+
+from state_mirror.backends import (
+    BACKEND_ENV,
+    DEFAULT_BACKEND,
+    Backend,
+    backend_from_env,
+    build_store,
+)
+from state_mirror.classifier import Classifier
+from state_mirror.handlers import make_handler
+
+UFM_VERSION = "7.0.1"
+WRITTEN_BY = "state-mirror:test"
+
+
+def _classifier(*entries):
+    return Classifier.from_dict({"entries": list(entries)})
+
+
+def _entry(key="ufm:state:a", path="/opt/ufm/files/conf/a.json"):
+    return {"path": path, "handler": "blob", "redis_key": key}
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        return object()  # stand-in Store
+
+
+class TestBackendFromEnv:
+    def test_default_is_configmap(self, monkeypatch):
+        monkeypatch.delenv(BACKEND_ENV, raising=False)
+        assert backend_from_env() is Backend.CONFIGMAP
+        assert DEFAULT_BACKEND is Backend.CONFIGMAP
+
+    def test_explicit_redis(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV, "redis")
+        assert backend_from_env() is Backend.REDIS
+
+    def test_case_and_whitespace_insensitive(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV, "  ConfigMap  ")
+        assert backend_from_env() is Backend.CONFIGMAP
+
+    def test_invalid_fails_closed(self, monkeypatch):
+        monkeypatch.setenv(BACKEND_ENV, "postgres")
+        with pytest.raises(ValueError, match="invalid"):
+            backend_from_env()
+
+
+class TestBuildStore:
+    def test_configmap_builds_only_configmap(self):
+        redis, cm = _Recorder(), _Recorder()
+        store = build_store(Backend.CONFIGMAP, redis_factory=redis, configmap_factory=cm)
+        assert cm.calls == 1
+        assert redis.calls == 0  # never construct the Redis client for a ConfigMap install
+        assert store is not None
+
+    def test_redis_builds_only_redis(self):
+        redis, cm = _Recorder(), _Recorder()
+        store = build_store(Backend.REDIS, redis_factory=redis, configmap_factory=cm)
+        assert redis.calls == 1
+        assert cm.calls == 0  # never load the K8s client for a Redis install
+        assert store is not None
+
+
+class TestMakeHandler:
+    def test_single_store_used_for_all(self):
+        only = object()
+        c = _classifier(_entry(), _entry(key="ufm:state:b", path="/opt/ufm/files/conf/b.json"))
+        for entry in c.entries:
+            h = make_handler(entry, only, UFM_VERSION, WRITTEN_BY)
+            assert h.store is only

--- a/ufm-state-mirror/tests/test_handlers.py
+++ b/ufm-state-mirror/tests/test_handlers.py
@@ -1,0 +1,248 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Unit tests for the StateMirror handlers (blob, directory, sqlite)."""
+
+import os
+import sqlite3
+
+from state_mirror.classifier import Entry
+from state_mirror.handlers import base, make_handler
+from state_mirror.handlers.base import BaseHandler
+from state_mirror.handlers.blob import BlobHandler
+from state_mirror.handlers.directory import DirectoryHandler
+from state_mirror.handlers.sqlite import SqliteHandler
+from state_mirror.store import RedisStore
+
+UFM_VERSION = "7.0.1"
+WRITTEN_BY = "state-mirror:test"
+
+
+def _handler(entry, client):
+    return make_handler(entry, RedisStore(client), UFM_VERSION, WRITTEN_BY)
+
+
+class TestBlobHandler:
+    def test_mirror_then_restore_roundtrip(self, fake_redis, tmp_path):
+        src = tmp_path / "a.json"
+        src.write_bytes(b'{"v": 1}')
+        entry = Entry.from_dict({"path": str(src), "handler": "blob", "redis_key": "ufm:state:a"})
+        handler = _handler(entry, fake_redis)
+        assert isinstance(handler, BlobHandler)
+
+        assert handler.mirror() is True
+        # unchanged -> idempotent no-op
+        assert handler.mirror() is False
+        # change -> ships again
+        src.write_bytes(b'{"v": 2}')
+        assert handler.mirror() is True
+
+        # restore into a fresh location
+        dest = tmp_path / "restored" / "a.json"
+        restore_entry = Entry.from_dict(
+            {"path": str(dest), "handler": "blob", "redis_key": "ufm:state:a"}
+        )
+        assert _handler(restore_entry, fake_redis).restore() is True
+        assert dest.read_bytes() == b'{"v": 2}'
+
+    def test_restore_missing_returns_false(self, fake_redis, tmp_path):
+        entry = Entry.from_dict(
+            {
+                "path": str(tmp_path / "x"),
+                "handler": "blob",
+                "redis_key": "ufm:state:none",
+            }
+        )
+        assert _handler(entry, fake_redis).restore() is False
+
+    def test_bootstrap_empty(self, fake_redis, tmp_path):
+        dest = tmp_path / "empty.conf"
+        entry = Entry.from_dict(
+            {
+                "path": str(dest),
+                "handler": "blob",
+                "redis_key": "ufm:state:empty",
+                "baseline": "empty",
+            }
+        )
+        _handler(entry, fake_redis).bootstrap()
+        assert dest.read_bytes() == b""
+        # bootstrap also pushed to redis, so a fresh restore now succeeds
+        assert _handler(entry, fake_redis).restore() is True
+
+    def test_on_delete(self, fake_redis, tmp_path):
+        src = tmp_path / "a.json"
+        src.write_bytes(b"x")
+        entry = Entry.from_dict({"path": str(src), "handler": "blob", "redis_key": "ufm:state:a"})
+        h = _handler(entry, fake_redis)
+        h.mirror()
+        h.on_delete()
+        assert fake_redis.get("ufm:state:a") is None
+        assert fake_redis.get("ufm:state:a:meta") is None
+
+
+class TestDirectoryHandler:
+    def test_directory_roundtrip(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        (root / "sub").mkdir(parents=True)
+        (root / "a.conf").write_bytes(b"AAA")
+        (root / "sub" / "b.conf").write_bytes(b"BBB")
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+                "recursive": True,
+            }
+        )
+        handler = _handler(entry, fake_redis)
+        assert isinstance(handler, DirectoryHandler)
+        assert handler.mirror() is True
+        assert fake_redis.get("ufm:cfg:plugins:a.conf") == b"AAA"
+        assert fake_redis.get("ufm:cfg:plugins:sub/b.conf") == b"BBB"
+
+        dest = tmp_path / "restored"
+        restore_entry = Entry.from_dict(
+            {
+                "path": str(dest),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+                "recursive": True,
+            }
+        )
+        assert _handler(restore_entry, fake_redis).restore() is True
+        assert (dest / "a.conf").read_bytes() == b"AAA"
+        assert (dest / "sub" / "b.conf").read_bytes() == b"BBB"
+
+    def test_child_delete(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "a.conf").write_bytes(b"AAA")
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+            }
+        )
+        handler = _handler(entry, fake_redis)
+        handler.mirror()
+        handler.on_delete_child("a.conf")
+        assert fake_redis.get("ufm:cfg:plugins:a.conf") is None
+
+
+class TestSqliteHandler:
+    @staticmethod
+    def _make_db(path, rows):
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        conn.executemany("INSERT INTO t (v) VALUES (?)", [(r,) for r in rows])
+        conn.commit()
+        conn.close()
+
+    def test_change_counter_increases(self, tmp_path):
+        db = str(tmp_path / "gv.db")
+        self._make_db(db, ["a"])
+        c1 = SqliteHandler.read_change_counter(db)
+        assert c1 > 0
+        conn = sqlite3.connect(db)
+        conn.execute("INSERT INTO t (v) VALUES ('b')")
+        conn.commit()
+        conn.close()
+        assert SqliteHandler.read_change_counter(db) > c1
+
+    def test_change_counter_missing_file(self, tmp_path):
+        assert SqliteHandler.read_change_counter(str(tmp_path / "nope.db")) == 0
+
+    def test_snapshot_mirror_and_restore(self, fake_redis, tmp_path):
+        db = str(tmp_path / "gv.db")
+        self._make_db(db, ["a", "b", "c"])
+        entry = Entry.from_dict(
+            {
+                "path": db,
+                "handler": "sqlite",
+                "redis_key": "ufm:sqlite:gv.db",
+                "snapshot_method": "online_backup",
+            }
+        )
+        handler = _handler(entry, fake_redis)
+        assert isinstance(handler, SqliteHandler)
+        assert handler.mirror() is True
+
+        # restore to a new path and confirm it opens with the same rows
+        dest = str(tmp_path / "restored" / "gv.db")
+        restore_entry = Entry.from_dict(
+            {"path": dest, "handler": "sqlite", "redis_key": "ufm:sqlite:gv.db"}
+        )
+        assert _handler(restore_entry, fake_redis).restore() is True
+        assert os.path.exists(dest)
+        conn = sqlite3.connect(dest)
+        count = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        conn.close()
+        assert count == 3
+
+
+class TestRestorePreservesIdentity:
+    """The root-run restore must not strip a file's original owner/mode when it
+    overwrites it via tmp+rename (e.g. conf/* is ufmapp 731:731)."""
+
+    def test_reapplies_owner_and_mode_on_overwrite(self, tmp_path, monkeypatch):
+        dest = tmp_path / "conf" / "unhealthy_ports_counters.csv"
+        dest.parent.mkdir(parents=True)
+        dest.write_bytes(b"old")
+
+        real_stat = os.stat
+        # Pretend the pre-existing file is owned by ufmapp 731:731, mode 0640.
+        seeded = os.stat_result((0o100640, 0, 0, 1, 731, 731, 3, 0, 0, 0))
+
+        def fake_stat(p, *a, **k):
+            if os.fspath(p) == str(dest):
+                return seeded
+            return real_stat(p, *a, **k)
+
+        chown_calls: list = []
+        chmod_calls: list = []
+        monkeypatch.setattr(base.os, "stat", fake_stat)
+        monkeypatch.setattr(base.os, "geteuid", lambda: 0)  # pretend root
+        monkeypatch.setattr(
+            base.os, "chown", lambda p, u, g: chown_calls.append((os.fspath(p), u, g))
+        )
+        monkeypatch.setattr(base.os, "chmod", lambda p, m: chmod_calls.append((os.fspath(p), m)))
+
+        BaseHandler._write_file(str(dest), b"new content")
+
+        assert dest.read_bytes() == b"new content"
+        assert chown_calls == [(str(dest), 731, 731)]
+        assert chmod_calls == [(str(dest), 0o640)]
+
+    def test_skips_chown_when_not_root(self, tmp_path, monkeypatch):
+        dest = tmp_path / "f.conf"
+        dest.write_bytes(b"old")
+        chown_calls: list = []
+        monkeypatch.setattr(base.os, "geteuid", lambda: 1000)
+        monkeypatch.setattr(base.os, "chown", lambda p, u, g: chown_calls.append(p))
+
+        BaseHandler._write_file(str(dest), b"new")
+
+        assert dest.read_bytes() == b"new"
+        assert chown_calls == []  # non-root: best-effort skip, never raises
+
+    def test_new_destination_is_left_to_default_ownership(self, tmp_path, monkeypatch):
+        dest = tmp_path / "brand_new.conf"  # does not pre-exist
+        chown_calls: list = []
+        monkeypatch.setattr(base.os, "geteuid", lambda: 0)
+        monkeypatch.setattr(base.os, "chown", lambda p, u, g: chown_calls.append(p))
+
+        BaseHandler._write_file(str(dest), b"hello")
+
+        assert dest.read_bytes() == b"hello"
+        assert chown_calls == []  # first-install file -> consumer owns it

--- a/ufm-state-mirror/tests/test_handlers.py
+++ b/ufm-state-mirror/tests/test_handlers.py
@@ -15,6 +15,9 @@
 import os
 import sqlite3
 
+import pytest
+
+from state_mirror import wire
 from state_mirror.classifier import Entry
 from state_mirror.handlers import base, make_handler
 from state_mirror.handlers.base import BaseHandler
@@ -138,6 +141,47 @@ class TestDirectoryHandler:
         handler.mirror()
         handler.on_delete_child("a.conf")
         assert fake_redis.get("ufm:cfg:plugins:a.conf") is None
+
+    def test_mirror_propagates_backend_error(self, fake_redis, tmp_path, monkeypatch):
+        # A backend failure on a child must NOT be swallowed: it propagates so
+        # the caller records the outage instead of seeing a healthy run (FIX-2).
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "a.conf").write_bytes(b"AAA")
+        entry = Entry.from_dict(
+            {"path": str(root), "handler": "directory", "redis_key_prefix": "ufm:cfg:plugins:"}
+        )
+        handler = _handler(entry, fake_redis)
+
+        def boom(*_a, **_k):
+            raise wire.WireError("backend down", reason="conn")
+
+        monkeypatch.setattr(handler.store, "get_meta", boom)
+        with pytest.raises(wire.WireError):
+            handler.mirror()
+
+    def test_mirror_skips_unreadable_child(self, fake_redis, tmp_path, monkeypatch):
+        # A local read error for one child is skipped (not fatal) so the rest of
+        # the tree still mirrors (FIX-2).
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "a.conf").write_bytes(b"AAA")
+        (root / "b.conf").write_bytes(b"BBB")
+        entry = Entry.from_dict(
+            {"path": str(root), "handler": "directory", "redis_key_prefix": "ufm:cfg:plugins:"}
+        )
+        handler = _handler(entry, fake_redis)
+        real_read = base.BaseHandler._read_file
+
+        def selective(path):
+            if path.endswith("a.conf"):
+                raise OSError("unreadable")
+            return real_read(path)
+
+        monkeypatch.setattr(base.BaseHandler, "_read_file", staticmethod(selective))
+        assert handler.mirror() is True  # b.conf still shipped despite a.conf failing
+        assert fake_redis.get("ufm:cfg:plugins:a.conf") is None
+        assert fake_redis.get("ufm:cfg:plugins:b.conf") == b"BBB"
 
 
 class TestSqliteHandler:

--- a/ufm-state-mirror/tests/test_sqlite.py
+++ b/ufm-state-mirror/tests/test_sqlite.py
@@ -137,3 +137,21 @@ class TestRestoreFailClosed:
         rh = _handler(tmp_path / "gv.db", fake_redis)
         with pytest.raises(sqlite3.Error):
             rh.restore()
+
+    def test_restore_does_not_clobber_live_db_on_corrupt_snapshot(self, fake_redis, tmp_path):
+        # A pre-existing, valid live DB must survive a corrupt stored snapshot:
+        # restore verifies on a temp copy first and fails closed WITHOUT touching
+        # the live file (FIX-1).
+        live = tmp_path / "gv.db"
+        _make_db(str(live), ["keep1", "keep2"])
+        key = "ufm:sqlite:gv.db"
+        body = b"this is not a sqlite database" * 10
+        meta = wire.build_meta(
+            body, handler="sqlite", ufm_version=UFM_VERSION, written_by=WRITTEN_BY
+        )
+        wire.write_pair(fake_redis, key, body, meta)
+        rh = _handler(live, fake_redis)
+        with pytest.raises(sqlite3.Error):
+            rh.restore()
+        # The live DB is intact -- its rows were never overwritten.
+        assert _row_count(str(live)) == 2

--- a/ufm-state-mirror/tests/test_sqlite.py
+++ b/ufm-state-mirror/tests/test_sqlite.py
@@ -1,0 +1,139 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Unit tests for the Phase 5 SQLite handler: snapshot-only online-backup
+mirroring, change detection, and integrity-checked, fail-closed restore."""
+
+import sqlite3
+
+import pytest
+
+from state_mirror import wire
+from state_mirror.classifier import Entry
+from state_mirror.handlers.sqlite import SqliteHandler
+from state_mirror.store import RedisStore
+
+UFM_VERSION = "7.0.1"
+WRITTEN_BY = "state-mirror:test"
+
+
+def _make_db(path, rows):
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+    conn.executemany("INSERT INTO t (v) VALUES (?)", [(r,) for r in rows])
+    conn.commit()
+    conn.close()
+
+
+def _row_count(path):
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _handler(path, fake_redis, **entry_overrides):
+    raw = {
+        "path": str(path),
+        "handler": "sqlite",
+        "redis_key": "ufm:sqlite:gv.db",
+        "snapshot_method": "online_backup",
+    }
+    raw.update(entry_overrides)
+    entry = Entry.from_dict(raw)
+    return SqliteHandler(entry, RedisStore(fake_redis), UFM_VERSION, WRITTEN_BY)
+
+
+class TestIntegrity:
+    def test_integrity_check_ok(self, tmp_path):
+        db = str(tmp_path / "gv.db")
+        _make_db(db, ["a", "b"])
+        SqliteHandler.integrity_check(db)  # no raise
+
+    def test_integrity_check_raises_on_corruption(self, tmp_path):
+        db = str(tmp_path / "gv.db")
+        _make_db(db, ["a", "b", "c"])
+        with open(db, "r+b") as f:
+            f.seek(4096)  # clobber page 2
+            f.write(b"\xde\xad\xbe\xef" * 512)
+        with pytest.raises(sqlite3.Error):
+            SqliteHandler.integrity_check(db)
+
+
+class TestSnapshot:
+    def test_mirror_skips_missing_and_empty(self, fake_redis, tmp_path):
+        h = _handler(tmp_path / "absent.db", fake_redis)
+        assert h.mirror() is False
+        empty = tmp_path / "empty.db"
+        empty.write_bytes(b"")
+        assert _handler(empty, fake_redis).mirror() is False
+
+    def test_snapshot_roundtrip(self, fake_redis, tmp_path):
+        db = tmp_path / "gv.db"
+        _make_db(str(db), ["a", "b", "c"])
+        h = _handler(db, fake_redis)
+        assert h.mirror() is True
+        assert h.mirror() is False  # unchanged -> no-op
+        assert fake_redis.get("ufm:sqlite:gv.db") is not None
+        # Snapshot-only: no WAL/epoch keys are ever written.
+        assert fake_redis.get("ufm:sqlite:gv.db:epoch") is None
+        assert fake_redis.get("ufm:sqlite:gv.db:wal:1") is None
+
+        dest = tmp_path / "restored" / "gv.db"
+        rh = _handler(dest, fake_redis)
+        assert rh.restore() is True
+        assert _row_count(str(dest)) == 3
+
+    def test_restore_missing_returns_false(self, fake_redis, tmp_path):
+        assert _handler(tmp_path / "x.db", fake_redis).restore() is False
+
+    def test_signature_changes_on_write(self, fake_redis, tmp_path):
+        db = str(tmp_path / "gv.db")
+        _make_db(db, ["a"])
+        h = _handler(db, fake_redis)
+        sig1 = h.signature()
+        conn = sqlite3.connect(db)
+        conn.execute("INSERT INTO t (v) VALUES ('b')")
+        conn.commit()
+        conn.close()
+        assert h.signature() != sig1
+
+    def test_mirror_reships_after_change(self, fake_redis, tmp_path):
+        db = tmp_path / "gv.db"
+        _make_db(str(db), ["a"])
+        h = _handler(db, fake_redis)
+        assert h.mirror() is True
+        conn = sqlite3.connect(str(db))
+        conn.execute("INSERT INTO t (v) VALUES ('b')")
+        conn.commit()
+        conn.close()
+        assert h.mirror() is True  # content changed -> re-shipped
+
+        dest = tmp_path / "restored" / "gv.db"
+        rh = _handler(dest, fake_redis)
+        assert rh.restore() is True
+        assert _row_count(str(dest)) == 2
+
+
+class TestRestoreFailClosed:
+    def test_restore_raises_on_corrupt_base(self, fake_redis, tmp_path):
+        # Store a base whose bytes are not a valid DB; restore must fail closed.
+        key = "ufm:sqlite:gv.db"
+        body = b"this is not a sqlite database" * 10
+        meta = wire.build_meta(
+            body, handler="sqlite", ufm_version=UFM_VERSION, written_by=WRITTEN_BY
+        )
+        wire.write_pair(fake_redis, key, body, meta)
+        rh = _handler(tmp_path / "gv.db", fake_redis)
+        with pytest.raises(sqlite3.Error):
+            rh.restore()


### PR DESCRIPTION
Third slice of the StateMirror sidecar (stacked on PR 2/4).

Adds the per-file-type mirror/restore logic and the wiring that binds it to a
backend:
- handlers: BaseHandler plus blob, atomic_blob, directory (per-child keys,
  realpath-containment guard on restore) and sqlite (consistent online-backup
  snapshot, WAL-aware change signature, fail-closed integrity check on
  restore). _write_file preserves the destination's uid/gid/mode across the
  tmp+rename so a root-run restore does not strip ownership.
- backends: install-wide backend selection (STATE_MIRROR_BACKEND) building a
  single Store at startup and binding each classifier entry's handler to it.

The mirror/restore entrypoints and health/metrics server follow in PR 4/4.
Tests: handlers, sqlite, backend routing; ruff clean.

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug, please reference. For
Bug fixes why and what can be merged in a single item._

## How ?
_It is optional, but for complex PRs please provide information about the design,
architecture, approach, etc._

## Testing ?
_How was this feature tested? Did you add unit tests? Did you add E2E tests?_

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
