### PR TITLE
state-mirror (4/4): runtime + health

### DIFF
--- a/ufm-state-mirror/state_mirror/health.py
+++ b/ufm-state-mirror/state_mirror/health.py
@@ -158,7 +158,9 @@ class HealthState:
 
     def snapshot(self) -> dict:
         with self._lock:
-            snap = dict(self.__dict__)
+            # Skip private attrs (e.g. the lock) so the result is a clean,
+            # serializable data-only snapshot.
+            snap = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
             snap["backend_errors"] = dict(self.backend_errors)
             snap["snapshot_durations"] = dict(self.snapshot_durations)
         return snap
@@ -179,7 +181,10 @@ def render_metrics(state: HealthState) -> str:
         lines.append(f"# TYPE {name} counter")
         lines.append(f"{name} {value}")
 
-    gauge("state_mirror_ready", "1 if the sidecar is ready", int(state.is_ready()))
+    # Derive readiness from the same snapshot (not a second is_ready() lock) so
+    # the gauge is consistent with the rest of this scrape.
+    ready = snap["watching_started"] and snap["startup_scan_done"]
+    gauge("state_mirror_ready", "1 if the sidecar is ready", int(ready))
     gauge(
         "state_mirror_backend_reachable",
         "1 if the storage backend was reachable on the last op",

--- a/ufm-state-mirror/state_mirror/health.py
+++ b/ufm-state-mirror/state_mirror/health.py
@@ -1,0 +1,294 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Readiness / liveness / metrics HTTP server for the sidecar (HLD 8.3 / R3).
+
+Exposes three endpoints on a small threaded HTTP server:
+
+    /ready    200 once restore/initial-scan is done and the watcher is armed;
+              503 otherwise. Gates UFM startup via the pod's native sidecar
+              readiness ordering.
+    /healthz  liveness of the *mirror loop itself*. Deliberately does NOT fail
+              when the storage backend is unreachable -- a backend outage must
+              not get the pod killed (that would lose the emptyDir). Backend
+              health is surfaced through metrics/alerts instead (HLD 8.6).
+    /metrics  Prometheus text exposition of the gauges/counters below.
+
+``HealthState`` is the thread-safe shared state updated by the mirror loop; the
+HTTP handlers only read snapshots of it.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from state_mirror.k8s_errors import K8S_ERROR_REASONS
+from state_mirror.redis_errors import REDIS_ERROR_REASONS
+
+log = logging.getLogger(__name__)
+
+DEFAULT_PORT = 9180
+LIVENESS_TIMEOUT_S = 30.0
+
+# The error-reason label set spans both backends so every series is present in
+# /metrics regardless of which one is selected at install time (HLD 8.6.2).
+BACKEND_ERROR_REASONS: tuple[str, ...] = tuple(
+    sorted(set(REDIS_ERROR_REASONS) | set(K8S_ERROR_REASONS))
+)
+
+
+class HealthState:
+    """Mutable, thread-safe view of the sidecar's health and counters."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.watching_started = False
+        self.startup_scan_done = False
+        self.watchdog_active = False
+        self.loop_started = False
+        self.last_loop_tick = 0.0
+        self.backend_reachable = False
+        self.last_store_write = 0.0
+        self.backend_errors = {reason: 0 for reason in BACKEND_ERROR_REASONS}
+        self.mirror_ops_total = 0
+        self.full_scans_total = 0
+        self.events_total = 0
+        self.dropped_events_total = 0
+        self.unexpected_deletes_total = 0
+        self.dirty_queue_depth = 0
+        self.pending_deletes = 0
+        # Last snapshot wall-clock per SQLite DB (basename label), HLD 5.3.4.
+        self.snapshot_durations: dict[str, float] = {}
+
+    def mark_watching(self, watchdog_active: bool) -> None:
+        with self._lock:
+            self.watching_started = True
+            self.watchdog_active = watchdog_active
+
+    def mark_startup_scan_done(self) -> None:
+        with self._lock:
+            self.startup_scan_done = True
+
+    def tick(self, dirty_depth: int, pending_deletes: int) -> None:
+        with self._lock:
+            self.loop_started = True
+            self.last_loop_tick = time.monotonic()
+            self.dirty_queue_depth = dirty_depth
+            self.pending_deletes = pending_deletes
+
+    def heartbeat(self) -> None:
+        """Mark forward progress without touching the queue depths.
+
+        Called from inside the long scan/drain loops so a slow backend (e.g. a
+        high-latency apiserver on the ConfigMap path, or a large SQLite snapshot)
+        keeps the liveness probe satisfied between ``tick`` calls. Without this a
+        single scan that runs longer than ``LIVENESS_TIMEOUT_S`` would get the pod
+        killed -- which would lose the emptyDir, the one thing we must never do.
+        """
+        with self._lock:
+            self.loop_started = True
+            self.last_loop_tick = time.monotonic()
+
+    def record_store_ok(self) -> None:
+        with self._lock:
+            self.backend_reachable = True
+            self.last_store_write = time.time()
+
+    def record_store_down(self, reason: str = "other") -> None:
+        with self._lock:
+            self.backend_reachable = False
+            if reason not in self.backend_errors:
+                reason = "other"
+            self.backend_errors[reason] += 1
+
+    def add_mirror_ops(self, n: int) -> None:
+        with self._lock:
+            self.mirror_ops_total += n
+
+    def inc_full_scans(self) -> None:
+        with self._lock:
+            self.full_scans_total += 1
+
+    def inc_events(self) -> None:
+        with self._lock:
+            self.events_total += 1
+
+    def inc_dropped_events(self, n: int = 1) -> None:
+        with self._lock:
+            self.dropped_events_total += n
+
+    def inc_unexpected_deletes(self, n: int = 1) -> None:
+        """Count files gone from emptyDir but still present in the backend.
+
+        Surfaces unobserved drift (HLD 5.3.7/5.3.9). The backend object is kept;
+        this is observability only, so an "alive but silently drifting" pod is
+        visible instead of failing closed.
+        """
+        with self._lock:
+            self.unexpected_deletes_total += n
+
+    def set_snapshot_duration(self, db: str, seconds: float) -> None:
+        """Record the last online-backup wall-clock for a SQLite DB (HLD 5.3.4)."""
+        with self._lock:
+            self.snapshot_durations[db] = seconds
+
+    def is_ready(self) -> bool:
+        with self._lock:
+            return self.watching_started and self.startup_scan_done
+
+    def is_alive(self, now: float | None = None, timeout: float = LIVENESS_TIMEOUT_S) -> bool:
+        if now is None:
+            now = time.monotonic()
+        with self._lock:
+            if not self.loop_started:
+                return True
+            return (now - self.last_loop_tick) <= timeout
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            snap = dict(self.__dict__)
+            snap["backend_errors"] = dict(self.backend_errors)
+            snap["snapshot_durations"] = dict(self.snapshot_durations)
+        return snap
+
+
+def render_metrics(state: HealthState) -> str:
+    """Render the Prometheus text exposition for the current state."""
+    snap = state.snapshot()
+    lines: list[str] = []
+
+    def gauge(name: str, help_text: str, value) -> None:
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} gauge")
+        lines.append(f"{name} {value}")
+
+    def counter(name: str, help_text: str, value) -> None:
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} counter")
+        lines.append(f"{name} {value}")
+
+    gauge("state_mirror_ready", "1 if the sidecar is ready", int(state.is_ready()))
+    gauge(
+        "state_mirror_backend_reachable",
+        "1 if the storage backend was reachable on the last op",
+        int(snap["backend_reachable"]),
+    )
+    gauge(
+        "state_mirror_watchdog_active",
+        "1 if the watchdog observer is running",
+        int(snap["watchdog_active"]),
+    )
+    gauge(
+        "state_mirror_last_write_timestamp_seconds",
+        "Unix time of the last successful store write (0 if never)",
+        snap["last_store_write"],
+    )
+    gauge("state_mirror_dirty_queue_depth", "Entries pending mirror", snap["dirty_queue_depth"])
+    gauge("state_mirror_pending_deletes", "Deletes pending propagation", snap["pending_deletes"])
+    counter(
+        "state_mirror_mirror_ops_total", "Total store write/delete ops", snap["mirror_ops_total"]
+    )
+    counter("state_mirror_full_scans_total", "Total full reconcile scans", snap["full_scans_total"])
+    counter("state_mirror_events_total", "Total watchdog change/delete marks", snap["events_total"])
+    counter(
+        "state_mirror_dropped_events_total",
+        "Delete marks dropped from a full bounded queue (D2 drop policy); "
+        "recovered by the next full-scan delete reconcile",
+        snap["dropped_events_total"],
+    )
+    counter(
+        "state_mirror_unexpected_delete_total",
+        "Files gone from emptyDir but still present in the backend (unobserved "
+        "drift, HLD 5.3.7/5.3.9); the backend object is kept (it wins on ambiguity)",
+        snap["unexpected_deletes_total"],
+    )
+
+    lines.append("# HELP state_mirror_backend_errors_total Backend op errors by classified reason")
+    lines.append("# TYPE state_mirror_backend_errors_total counter")
+    for reason, count in sorted(snap["backend_errors"].items()):
+        lines.append(f'state_mirror_backend_errors_total{{reason="{reason}"}} {count}')
+
+    lines.append(
+        "# HELP state_mirror_snapshot_duration_seconds "
+        "Wall-clock of the last SQLite online-backup snapshot per DB"
+    )
+    lines.append("# TYPE state_mirror_snapshot_duration_seconds gauge")
+    for db, seconds in sorted(snap["snapshot_durations"].items()):
+        lines.append(f'state_mirror_snapshot_duration_seconds{{db="{db}"}} {seconds}')
+
+    return "\n".join(lines) + "\n"
+
+
+def handle_request(path: str, state: HealthState) -> tuple[int, str, bytes]:
+    """Pure router: map a request path to ``(status, content_type, body)``."""
+    if path == "/ready":
+        if state.is_ready():
+            return 200, "text/plain", b"ready\n"
+        return 503, "text/plain", b"not ready\n"
+    if path == "/healthz":
+        if state.is_alive():
+            return 200, "text/plain", b"ok\n"
+        return 503, "text/plain", b"unhealthy\n"
+    if path == "/metrics":
+        return 200, "text/plain; version=0.0.4", render_metrics(state).encode("utf-8")
+    return 404, "text/plain", b"not found\n"
+
+
+def _make_handler(state: HealthState):
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+            path = self.path.split("?", 1)[0]
+            status, content_type, body = handle_request(path, state)
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):  # silence default stderr access logging
+            pass
+
+    return _Handler
+
+
+class HealthServer:
+    """Runs :func:`handle_request` over HTTP in a daemon thread. Fail-soft."""
+
+    def __init__(self, state: HealthState, port: int = DEFAULT_PORT, host: str = "0.0.0.0"):
+        self.state = state
+        self.port = port
+        self.host = host
+        self._httpd = None
+        self._thread = None
+
+    def start(self) -> bool:
+        try:
+            self._httpd = ThreadingHTTPServer((self.host, self.port), _make_handler(self.state))
+        except OSError as exc:
+            log.error("health server failed to bind %s:%d: %s", self.host, self.port, exc)
+            return False
+        self._thread = threading.Thread(
+            target=self._httpd.serve_forever,
+            name="state-mirror-health",
+            daemon=True,
+        )
+        self._thread.start()
+        log.info("health/metrics server listening on %s:%d", self.host, self.port)
+        return True
+
+    def stop(self) -> None:
+        if self._httpd:
+            self._httpd.shutdown()
+            self._httpd.server_close()

--- a/ufm-state-mirror/state_mirror/mirror.py
+++ b/ufm-state-mirror/state_mirror/mirror.py
@@ -318,6 +318,14 @@ class Mirror:
             self.state.mark_watching(watchdog_active=False)
 
     def run_forever(self, scan_interval_s: float = 60.0, poll_interval_s: float = 0.5) -> None:
+        """Run the mirror loop until the process is killed.
+
+        ``scan_interval_s`` (default 60s) is how often the periodic full scan
+        reconciles anything the watch events missed. ``poll_interval_s`` (default
+        0.5s) is the loop wake interval that drains queued watch events -- it is
+        NOT the per-DB SQLite cadence, which is each entry's ``poll_interval_ms``
+        enforced inside :meth:`poll_sqlite`.
+        """
         self.start_watching()
         log.info("startup full scan (%d entries)", len(self._handlers))
         self.full_scan()

--- a/ufm-state-mirror/state_mirror/mirror.py
+++ b/ufm-state-mirror/state_mirror/mirror.py
@@ -1,0 +1,374 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""StateMirror runtime sidecar: continuously mirror emptyDir -> storage backend
+(HLD 5.3.2 / 5.3.7).
+
+Change detection is event-driven (watchdog) and drained on a short loop so the
+watch callback never blocks on backend I/O. A periodic full scan reconciles
+anything events missed, and SQLite DBs are polled by their change-counter. All
+backend failures are caught, classified, and surfaced via the health/metrics
+state -- a backend outage degrades mirroring but never crashes the sidecar
+(which would lose the emptyDir).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections import OrderedDict
+
+from state_mirror.classifier import Classifier, Entry, Handler
+from state_mirror.handlers import make_handler
+from state_mirror.handlers.sqlite import SqliteHandler
+from state_mirror.health import DEFAULT_PORT, HealthServer, HealthState
+from state_mirror.redis_errors import classify_redis_error
+from state_mirror.watcher import MirrorEventHandler, PathResolver, build_observer
+
+log = logging.getLogger("state_mirror.mirror")
+
+# D2: upper bound on the in-memory delete queue. The dirty queue is a set keyed
+# by entry path, so it is already bounded by the number of classifier entries;
+# the delete queue fans out per directory child and is the one that can grow
+# during a long backend outage, so it gets an explicit cap with a drop policy.
+DEFAULT_MAX_QUEUE = 100_000
+
+
+def _reason(exc: BaseException) -> str:
+    """Best reason for a failed mirror op: the WireError's classified reason if
+    present (set at the store boundary, by the active backend's classifier),
+    else fall back to a generic transport/OS classification.
+    """
+    return getattr(exc, "reason", None) or classify_redis_error(exc)
+
+
+class Mirror:
+    def __init__(
+        self,
+        classifier: Classifier,
+        store,
+        ufm_version: str,
+        written_by: str,
+        state: HealthState | None = None,
+        max_queue: int = DEFAULT_MAX_QUEUE,
+    ):
+        self.store = store
+        self._handlers = [
+            make_handler(e, store, ufm_version, written_by) for e in classifier.entries
+        ]
+        self._by_path = {h.entry.path: h for h in self._handlers}
+        # Per-sqlite-DB last-poll time so a DB is fingerprinted no more often than
+        # its poll_interval_ms. The change fingerprint itself lives on the handler
+        # (SqliteHandler gates its own snapshot), so there is no signature cache here.
+        self._sql_last_poll: dict[str, float] = {}
+        self.state = state or HealthState()
+        self._resolver = PathResolver(classifier.entries)
+        self._lock = threading.Lock()
+        self._dirty: set[str] = set()
+        # Deletes the sidecar actually *observed* (watchdog delete/move-out),
+        # awaiting propagation. Keyed by store key so duplicates collapse and the
+        # drift scan can exclude them; value is (entry_path, fs_path). Only keys in
+        # here are ever removed from the backend -- an unobserved missing file is
+        # drift, never a delete (HLD 5.3.7/5.3.9, "the backend wins on ambiguity").
+        self._pending_deletes: OrderedDict[str, tuple[str, str]] = OrderedDict()
+        self._max_queue = max(1, max_queue)
+        # Keys already counted as unobserved drift (file gone but backend has it),
+        # so persistent drift bumps state_mirror_unexpected_delete_total once per
+        # onset rather than every scan (HLD 5.3.7).
+        self._known_drift: set[str] = set()
+        self._last_ship: dict[str, float] = {}
+        self._wakeup = threading.Event()
+        self._event_handler = MirrorEventHandler(
+            self._resolver, self._mark_dirty, self._mark_delete
+        )
+        self._observer = None
+
+    def _mark_dirty(self, entry: Entry) -> None:
+        with self._lock:
+            self._dirty.add(entry.path)
+        self.state.inc_events()
+        self._wakeup.set()
+
+    def _mark_delete(self, entry: Entry, fs_path: str) -> None:
+        handler = self._by_path.get(entry.path)
+        if handler is None:
+            return
+        key = handler.key_for_fs_path(fs_path)
+        dropped = 0
+        with self._lock:
+            # Collapse duplicate observations of the same key; keep it newest.
+            self._pending_deletes.pop(key, None)
+            self._pending_deletes[key] = (entry.path, fs_path)
+            # D2 drop policy: bound memory during a long backend outage by dropping
+            # the OLDEST pending delete (O(1) on an OrderedDict). A dropped delete
+            # is simply not propagated -- the file stays in the backend and is
+            # re-materialized on the next restore (the backend wins), so we never
+            # leak unbounded memory and never mistakenly delete on ambiguity.
+            while len(self._pending_deletes) > self._max_queue:
+                self._pending_deletes.popitem(last=False)
+                dropped += 1
+        if dropped:
+            log.warning(
+                "delete queue full (max=%d); dropped %d oldest delete(s); "
+                "those files stay in the backend until next restore",
+                self._max_queue,
+                dropped,
+            )
+            self.state.inc_dropped_events(dropped)
+        self.state.inc_events()
+        self._wakeup.set()
+
+    def drain_once(self, now: float, rate_limited: bool = True) -> int:
+        """Process queued watchdog marks. Returns the number of store ops.
+
+        Honors each entry's ``rate_limit_ms`` so a hot file is coalesced rather
+        than shipped on every event; deferred paths are requeued.
+        """
+        with self._lock:
+            dirty = list(self._dirty)
+            self._dirty = set()
+        ops = 0
+        requeue: set[str] = set()
+        for path in dirty:
+            self.state.heartbeat()
+            handler = self._by_path.get(path)
+            if handler is None:
+                continue
+            entry = handler.entry
+            if (
+                rate_limited
+                and entry.rate_limit_ms
+                and path in self._last_ship
+                and (now - self._last_ship[path]) * 1000.0 < entry.rate_limit_ms
+            ):
+                requeue.add(path)
+                continue
+            try:
+                if handler.mirror():
+                    ops += 1
+                self._last_ship[path] = now
+                self.state.record_store_ok()
+            except Exception as exc:
+                reason = _reason(exc)
+                log.exception("event mirror failed for %s [%s]; will retry", path, reason)
+                self.state.record_store_down(reason)
+                requeue.add(path)
+        if requeue:
+            with self._lock:
+                self._dirty |= requeue
+        ops += self.flush_pending_deletes()
+        if ops:
+            self.state.add_mirror_ops(ops)
+        return ops
+
+    def flush_pending_deletes(self) -> int:
+        """Propagate observed deletes to the backend; retry the ones that failed.
+
+        Only keys the sidecar actually observed being deleted are in
+        ``_pending_deletes``, so this never removes a backend object for a file
+        that merely went missing unobserved (that is drift -- see
+        :meth:`_scan_unexpected_deletes`). A delete whose file reappeared before
+        we propagated it is dropped (no longer a delete). Returns ops applied.
+        """
+        with self._lock:
+            items = list(self._pending_deletes.items())
+        ops = 0
+        for key, (entry_path, fs_path) in items:
+            self.state.heartbeat()
+            if os.path.exists(fs_path):
+                with self._lock:
+                    self._pending_deletes.pop(key, None)
+                continue
+            try:
+                self._apply_delete(entry_path, fs_path)
+                with self._lock:
+                    self._pending_deletes.pop(key, None)
+                ops += 1
+                self.state.record_store_ok()
+            except Exception as exc:
+                reason = _reason(exc)
+                log.exception("delete failed for %s [%s]; will retry next cycle", key, reason)
+                self.state.record_store_down(reason)
+        return ops
+
+    def _apply_delete(self, entry_path: str, fs_path: str) -> None:
+        handler = self._by_path.get(entry_path)
+        if handler is None:
+            return
+        if handler.entry.is_directory:
+            handler.on_delete_child(os.path.relpath(fs_path, entry_path))
+        else:
+            handler.on_delete()
+
+    def full_scan(self) -> int:
+        """Mirror every entry whose body differs from the store. Returns #sent.
+
+        Also retries any observed-but-unpropagated deletes and accounts for
+        unobserved drift (HLD 5.3.7). Heartbeats per entry so a slow backend can
+        extend the scan without tripping the liveness probe.
+        """
+        sent = 0
+        for handler in self._handlers:
+            self.state.heartbeat()
+            try:
+                if handler.mirror():
+                    sent += 1
+                self.state.record_store_ok()
+            except Exception as exc:
+                reason = _reason(exc)
+                log.exception("mirror failed for %s [%s]", handler.entry.path, reason)
+                self.state.record_store_down(reason)
+        flushed = self.flush_pending_deletes()
+        self._scan_unexpected_deletes()
+        self.state.inc_full_scans()
+        total = sent + flushed
+        if total:
+            self.state.add_mirror_ops(total)
+        return sent
+
+    def _scan_unexpected_deletes(self) -> int:
+        """Count keys present in the backend whose local file vanished (HLD 5.3.7).
+
+        Does not delete anything (the backend wins on ambiguity); only bumps
+        ``state_mirror_unexpected_delete_total`` for keys newly entering drift, so
+        the gap is visible instead of silent. Keys with an observed delete still
+        pending propagation are excluded -- those are intended deletes, not drift.
+        Returns the number of newly-drifted keys. Reads only, so it never updates
+        the last-write timestamp (which would mask mirror lag).
+        """
+        with self._lock:
+            pending = set(self._pending_deletes)
+        current: set[str] = set()
+        for handler in self._handlers:
+            self.state.heartbeat()
+            try:
+                current.update(handler.drift_keys())
+            except Exception as exc:
+                reason = _reason(exc)
+                log.exception("drift check failed for %s [%s]", handler.entry.path, reason)
+                self.state.record_store_down(reason)
+        current -= pending
+        new_drift = current - self._known_drift
+        self._known_drift = current
+        if new_drift:
+            log.warning(
+                "drift: %d object(s) present in backend but missing locally; "
+                "keeping backend copy (HLD 5.3.7): %s",
+                len(new_drift),
+                sorted(new_drift),
+            )
+            self.state.inc_unexpected_deletes(len(new_drift))
+        return len(new_drift)
+
+    def poll_sqlite(self, now: float | None = None) -> int:
+        now = time.monotonic() if now is None else now
+        sent = 0
+        for handler in self._handlers:
+            if handler.entry.handler is not Handler.SQLITE or not isinstance(
+                handler, SqliteHandler
+            ):
+                continue
+            path = handler.entry.path
+            # Per-DB rate limit: bound snapshot frequency (cheap for small DBs,
+            # important once a DB is large).
+            interval_s = handler.entry.poll_interval_ms / 1000.0
+            last = self._sql_last_poll.get(path)
+            if last is not None and (now - last) < interval_s:
+                continue
+            self._sql_last_poll[path] = now
+            self.state.heartbeat()
+            try:
+                # mirror() self-gates on the WAL-aware fingerprint, so an idle DB
+                # is just a cheap header read; only an actual change snapshots.
+                if handler.mirror():
+                    sent += 1
+                if handler.last_snapshot_seconds is not None:
+                    self.state.set_snapshot_duration(
+                        os.path.basename(path), handler.last_snapshot_seconds
+                    )
+                self.state.record_store_ok()
+            except Exception as exc:
+                reason = _reason(exc)
+                log.exception("sqlite snapshot failed for %s [%s]", path, reason)
+                self.state.record_store_down(reason)
+        if sent:
+            self.state.add_mirror_ops(sent)
+        return sent
+
+    def start_watching(self) -> None:
+        """Arm the watchdog observer. Fail-soft: poll-only if it can't start."""
+        try:
+            self._observer = build_observer(self._resolver, self._event_handler)
+            self._observer.start()
+            log.info("watchdog observer started")
+            self.state.mark_watching(watchdog_active=True)
+        except Exception:
+            log.exception("watchdog observer failed to start; running poll-only")
+            self.state.mark_watching(watchdog_active=False)
+
+    def run_forever(self, scan_interval_s: float = 60.0, poll_interval_s: float = 0.5) -> None:
+        self.start_watching()
+        log.info("startup full scan (%d entries)", len(self._handlers))
+        self.full_scan()
+        self.state.mark_startup_scan_done()
+        last_scan = time.monotonic()
+        while True:
+            try:
+                self._wakeup.wait(timeout=poll_interval_s)
+                self._wakeup.clear()
+                now = time.monotonic()
+                self.drain_once(now=now)
+                # poll_sqlite enforces each DB's own poll_interval_ms internally.
+                self.poll_sqlite(now=now)
+                if now - last_scan >= scan_interval_s:
+                    self.full_scan()
+                    last_scan = now
+                with self._lock:
+                    dirty_depth = len(self._dirty)
+                    pending = len(self._pending_deletes)
+                self.state.tick(dirty_depth=dirty_depth, pending_deletes=pending)
+            except Exception:
+                log.exception("mirror loop iteration failed; retrying")
+
+
+def main() -> int:
+    from state_mirror.backends import backend_from_env, build_store
+    from state_mirror.logconfig import setup_logging
+
+    global log
+    log = setup_logging("state_mirror.mirror")
+    classifier_path = os.environ.get("CLASSIFIER_PATH", "/etc/state_mirror/state_mirror.yaml")
+    ufm_version = os.environ.get("UFM_VERSION", "unknown")
+    written_by = "state-mirror:" + os.environ.get("STATE_MIRROR_GIT_SHA", "dev")
+    port = int(os.environ.get("STATE_MIRROR_METRICS_PORT", DEFAULT_PORT))
+    max_queue = int(os.environ.get("STATE_MIRROR_MAX_QUEUE", DEFAULT_MAX_QUEUE))
+    log.info("state-mirror sidecar starting (ufm_version=%s, max_queue=%d)", ufm_version, max_queue)
+
+    state = HealthState()
+    HealthServer(state, port=port).start()
+    try:
+        classifier = Classifier.load_file(classifier_path)
+        store = build_store(backend_from_env())
+        mirror = Mirror(
+            classifier, store, ufm_version, written_by, state=state, max_queue=max_queue
+        )
+    except Exception:
+        log.exception("state-mirror sidecar failed to initialize")
+        return 1
+    mirror.run_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ufm-state-mirror/state_mirror/restore.py
+++ b/ufm-state-mirror/state_mirror/restore.py
@@ -1,0 +1,86 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""StateMirror init container: materialize the storage backend -> emptyDir
+before UFM starts (HLD 5.3.2 / 5.3.6 / 5.3.8).
+
+Runs once, to completion, as a Kubernetes init container so UFM never starts on
+partial state. Every classifier entry is either restored from the backend or,
+on first install (no stored object), seeded from its baseline. Any restore
+failure exits non-zero so the pod fails closed rather than booting UFM on
+incomplete state.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from state_mirror.classifier import Classifier
+from state_mirror.handlers import make_handler
+
+log = logging.getLogger("state_mirror.restore")
+
+
+def run(classifier: Classifier, store, ufm_version: str) -> int:
+    """Restore every entry from the install-wide ``store`` (HLD 5.2.3, 5.3.6)."""
+    log.info("restore: %d classifier entries", len(classifier))
+    restored, bootstrapped = 0, 0
+    written_by = _written_by()
+    for entry in classifier.entries:
+        handler = make_handler(entry, store, ufm_version, written_by)
+        try:
+            if handler.restore():
+                restored += 1
+                log.info("restored %s", entry.path)
+            else:
+                handler.bootstrap()
+                bootstrapped += 1
+                log.info("bootstrapped %s (baseline=%s)", entry.path, entry.baseline.value)
+        except Exception:
+            log.exception("restore failed for entry %s; failing closed", entry.path)
+            return 1
+    log.info("restore complete: %d restored, %d bootstrapped", restored, bootstrapped)
+    return 0
+
+
+def main() -> int:
+    import os
+
+    from state_mirror.backends import backend_from_env, build_store
+    from state_mirror.logconfig import setup_logging
+
+    global log
+    log = setup_logging("state_mirror.restore")
+    classifier_path = os.environ.get("CLASSIFIER_PATH", "/etc/state_mirror/state_mirror.yaml")
+    ufm_version = os.environ.get("UFM_VERSION", "unknown")
+    log.info("state-mirror restore starting (ufm_version=%s)", ufm_version)
+    try:
+        classifier = Classifier.load_file(classifier_path)
+        store = build_store(backend_from_env())
+        rc = run(classifier, store, ufm_version)
+    except Exception:
+        log.exception("restore failed; refusing to start UFM on incomplete state")
+        return 1
+    if rc == 0:
+        log.info("state-mirror restore finished successfully")
+    return rc
+
+
+def _written_by() -> str:
+    import os
+
+    return "state-mirror:" + os.environ.get("STATE_MIRROR_GIT_SHA", "dev")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ufm-state-mirror/state_mirror/restore.py
+++ b/ufm-state-mirror/state_mirror/restore.py
@@ -27,11 +27,12 @@ import sys
 
 from state_mirror.classifier import Classifier
 from state_mirror.handlers import make_handler
+from state_mirror.store import Store
 
 log = logging.getLogger("state_mirror.restore")
 
 
-def run(classifier: Classifier, store, ufm_version: str) -> int:
+def run(classifier: Classifier, store: Store, ufm_version: str) -> int:
     """Restore every entry from the install-wide ``store`` (HLD 5.2.3, 5.3.6)."""
     log.info("restore: %d classifier entries", len(classifier))
     restored, bootstrapped = 0, 0

--- a/ufm-state-mirror/state_mirror/watcher.py
+++ b/ufm-state-mirror/state_mirror/watcher.py
@@ -100,7 +100,23 @@ class MirrorEventHandler:
         if event_type == EVENT_CLOSED:
             self._dirty(event.src_path)
         elif event_type == EVENT_MOVED:
-            self._dirty(getattr(event, "dest_path", None) or event.src_path)
+            dest = getattr(event, "dest_path", None) or event.src_path
+            self._dirty(dest)
+            # The move is observed, so honor it: if the OLD path was a tracked
+            # entry (a renamed single file, or a child inside a watched dir), its
+            # backend key must be dropped or a later restore revives the file at
+            # the old location. Safe against atomic write-temp-then-rename -- the
+            # drain only deletes when the source path is actually gone and
+            # store.delete is idempotent, so a move-then-recreate is a no-op.
+            if event.src_path != dest:
+                src_entry = self._resolver.resolve(event.src_path)
+                if src_entry is not None:
+                    log.debug(
+                        "watchdog move: queuing delete for old path %s -> entry %s",
+                        event.src_path,
+                        src_entry.path,
+                    )
+                    self._mark_delete(src_entry, event.src_path)
         elif event_type == EVENT_DELETED:
             entry = self._resolver.resolve(event.src_path)
             if entry is not None:
@@ -126,6 +142,8 @@ def build_observer(resolver: PathResolver, handler: MirrorEventHandler):
     scheduled = 0
     for directory, recursive in resolver.watch_dirs():
         try:
+            if not os.path.isdir(directory):
+                log.info("creating missing watch directory %s", directory)
             os.makedirs(directory, exist_ok=True)
             observer.schedule(handler, directory, recursive=recursive)
             log.info("watching %s (recursive=%s)", directory, recursive)

--- a/ufm-state-mirror/state_mirror/watcher.py
+++ b/ufm-state-mirror/state_mirror/watcher.py
@@ -1,0 +1,136 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Event-driven change detection for the StateMirror sidecar (HLD 5.3.2).
+
+Uses the ``watchdog`` library for cross-platform filesystem events. This module
+maps raw events to classifier entries (``PathResolver``), translates them into
+mirror/delete marks (``MirrorEventHandler``), and schedules the watches
+(``build_observer``). The actual Redis work is deferred to the mirror loop's
+drain so the watch callback stays fast and never blocks on I/O.
+
+watchdog itself is imported lazily inside ``build_observer`` so the resolver and
+dispatch logic stay unit testable without the dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Callable, Optional
+
+from state_mirror.classifier import Entry
+
+log = logging.getLogger(__name__)
+
+# watchdog event_type values we care about.
+EVENT_CLOSED = "closed"
+EVENT_MOVED = "moved"
+EVENT_DELETED = "deleted"
+
+
+class PathResolver:
+    """Map a filesystem path to the classifier entry that governs it."""
+
+    def __init__(self, entries: list[Entry]):
+        self._single: dict[str, Entry] = {}
+        self._dirs: list[tuple[str, Entry]] = []
+        for e in entries:
+            if e.is_directory:
+                self._dirs.append((os.path.normpath(e.path), e))
+            else:
+                self._single[os.path.normpath(e.path)] = e
+        # Longest (most specific) directory first.
+        self._dirs.sort(key=lambda re: len(re[0]), reverse=True)
+
+    def resolve(self, path: str) -> Optional[Entry]:
+        p = os.path.normpath(path)
+        entry = self._single.get(p)
+        if entry is not None:
+            return entry
+        for dirpath, e in self._dirs:
+            if p.startswith(dirpath + os.sep) and (e.recursive or os.path.dirname(p) == dirpath):
+                return e
+        return None
+
+    def watch_dirs(self) -> list[tuple[str, bool]]:
+        """Return deduped ``(directory, recursive)`` pairs to schedule.
+
+        Single-file entries are watched via their parent directory (watchdog
+        watches directories, not files), non-recursively.
+        """
+        dirs: dict[str, bool] = {}
+        for p in self._single:
+            dirs.setdefault(os.path.dirname(p), False)
+        for dirpath, e in self._dirs:
+            dirs[dirpath] = bool(e.recursive) or dirs.get(dirpath, False)
+        return list(dirs.items())
+
+
+class MirrorEventHandler:
+    """Duck-typed watchdog handler: watchdog only needs a ``dispatch(event)``.
+
+    Deliberately does no Redis I/O -- it only marks work for the mirror loop so
+    the watch thread never blocks.
+    """
+
+    def __init__(
+        self,
+        resolver: PathResolver,
+        mark_dirty: Callable[[Entry], None],
+        mark_delete: Callable[[Entry, str], None],
+    ):
+        self._resolver = resolver
+        self._mark_dirty = mark_dirty
+        self._mark_delete = mark_delete
+
+    def dispatch(self, event) -> None:
+        if getattr(event, "is_directory", False):
+            return
+        event_type = getattr(event, "event_type", None)
+        if event_type == EVENT_CLOSED:
+            self._dirty(event.src_path)
+        elif event_type == EVENT_MOVED:
+            self._dirty(getattr(event, "dest_path", None) or event.src_path)
+        elif event_type == EVENT_DELETED:
+            entry = self._resolver.resolve(event.src_path)
+            if entry is not None:
+                log.debug("watchdog deleted %s -> entry %s", event.src_path, entry.path)
+                self._mark_delete(entry, event.src_path)
+
+    def _dirty(self, path: str) -> None:
+        entry = self._resolver.resolve(path)
+        if entry is not None:
+            log.debug("watchdog change %s -> entry %s", path, entry.path)
+            self._mark_dirty(entry)
+
+
+def build_observer(resolver: PathResolver, handler: MirrorEventHandler):
+    """Create, schedule, and return a watchdog ``Observer`` (not started).
+
+    Missing watch directories are created; a directory that cannot be watched is
+    logged and skipped (the periodic full scan still covers it).
+    """
+    from watchdog.observers import Observer
+
+    observer = Observer()
+    scheduled = 0
+    for directory, recursive in resolver.watch_dirs():
+        try:
+            os.makedirs(directory, exist_ok=True)
+            observer.schedule(handler, directory, recursive=recursive)
+            log.info("watching %s (recursive=%s)", directory, recursive)
+            scheduled += 1
+        except OSError as exc:
+            log.error("cannot watch %s: %s (relying on periodic scan)", directory, exc)
+    log.info("watchdog scheduled %d watch(es)", scheduled)
+    return observer

--- a/ufm-state-mirror/tests/test_health.py
+++ b/ufm-state-mirror/tests/test_health.py
@@ -1,0 +1,175 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Unit tests for the readiness/liveness/metrics server."""
+
+import urllib.error
+import urllib.request
+
+from state_mirror.health import HealthServer, HealthState, handle_request, render_metrics
+
+
+def _get(url):
+    """GET returning (status, body), treating HTTP error codes as responses."""
+    try:
+        with urllib.request.urlopen(url) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+class TestReadiness:
+    def test_not_ready_until_milestones(self):
+        s = HealthState()
+        assert s.is_ready() is False
+        s.mark_watching(watchdog_active=True)
+        assert s.is_ready() is False
+        s.mark_startup_scan_done()
+        assert s.is_ready() is True
+
+    def test_ready_route(self):
+        s = HealthState()
+        status, _ct, body = handle_request("/ready", s)
+        assert status == 503
+        assert body == b"not ready\n"
+        s.mark_watching(watchdog_active=True)
+        s.mark_startup_scan_done()
+        status, _ct, body = handle_request("/ready", s)
+        assert status == 200
+        assert body == b"ready\n"
+
+
+class TestLiveness:
+    def test_alive_before_loop_starts(self):
+        s = HealthState()
+        assert s.is_alive() is True
+
+    def test_alive_with_recent_tick(self):
+        s = HealthState()
+        s.tick(0, 0)
+        assert s.is_alive() is True
+
+    def test_dead_when_loop_stalls(self):
+        s = HealthState()
+        s.tick(0, 0)
+        s.last_loop_tick = 1.0
+        assert s.is_alive(now=1000.0, timeout=30.0) is False
+
+    def test_healthz_route(self):
+        s = HealthState()
+        status, _ct, _body = handle_request("/healthz", s)
+        assert status == 200
+
+    def test_liveness_ignores_backend_down(self):
+        s = HealthState()
+        s.tick(0, 0)
+        s.record_store_down()
+        assert s.is_alive() is True
+
+
+class TestMetrics:
+    def test_metrics_route_content_type(self):
+        s = HealthState()
+        status, content_type, body = handle_request("/metrics", s)
+        assert status == 200
+        assert "text/plain" in content_type
+        assert b"state_mirror_ready" in body
+
+    def test_metrics_reflect_state(self):
+        s = HealthState()
+        s.mark_watching(watchdog_active=True)
+        s.mark_startup_scan_done()
+        s.record_store_ok()
+        s.add_mirror_ops(3)
+        s.inc_full_scans()
+        s.inc_events()
+        text = render_metrics(s)
+        assert "state_mirror_ready 1" in text
+        assert "state_mirror_backend_reachable 1" in text
+        assert "state_mirror_watchdog_active 1" in text
+        assert "state_mirror_mirror_ops_total 3" in text
+        assert "state_mirror_full_scans_total 1" in text
+        assert "state_mirror_events_total 1" in text
+        assert text.count("# HELP") == text.count("# TYPE")
+
+    def test_unknown_route_404(self):
+        s = HealthState()
+        status, _ct, body = handle_request("/nope", s)
+        assert status == 404
+        assert body == b"not found\n"
+
+    def test_backend_errors_series_present_at_zero(self):
+        text = render_metrics(HealthState())
+        # A reason from each backend's label set is pre-seeded to 0.
+        assert 'state_mirror_backend_errors_total{reason="oom"} 0' in text  # redis
+        assert 'state_mirror_backend_errors_total{reason="forbidden"} 0' in text  # configmap
+        assert 'state_mirror_backend_errors_total{reason="conn"} 0' in text  # shared
+
+    def test_backend_errors_counter_increments_by_reason(self):
+        s = HealthState()
+        s.record_store_down("oom")
+        s.record_store_down("oom")
+        s.record_store_down("forbidden")
+        text = render_metrics(s)
+        assert 'state_mirror_backend_errors_total{reason="oom"} 2' in text
+        assert 'state_mirror_backend_errors_total{reason="forbidden"} 1' in text
+        assert s.backend_reachable is False
+
+    def test_unknown_reason_buckets_to_other(self):
+        s = HealthState()
+        s.record_store_down("not-a-real-reason")
+        text = render_metrics(s)
+        assert 'state_mirror_backend_errors_total{reason="other"} 1' in text
+
+    def test_dropped_events_counter(self):
+        s = HealthState()
+        assert "state_mirror_dropped_events_total 0" in render_metrics(s)
+        s.inc_dropped_events(5)
+        assert "state_mirror_dropped_events_total 5" in render_metrics(s)
+
+    def test_unexpected_delete_counter(self):
+        s = HealthState()
+        assert "state_mirror_unexpected_delete_total 0" in render_metrics(s)
+        s.inc_unexpected_deletes(2)
+        assert "state_mirror_unexpected_delete_total 3" not in render_metrics(s)
+        s.inc_unexpected_deletes()
+        assert "state_mirror_unexpected_delete_total 3" in render_metrics(s)
+
+    def test_snapshot_duration_gauge_labeled_by_db(self):
+        s = HealthState()
+        # Present (with HELP/TYPE) even before any snapshot.
+        assert "state_mirror_snapshot_duration_seconds" in render_metrics(s)
+        s.set_snapshot_duration("gv.db", 0.42)
+        text = render_metrics(s)
+        assert 'state_mirror_snapshot_duration_seconds{db="gv.db"} 0.42' in text
+
+
+class TestLiveServer:
+    def test_end_to_end_over_http(self):
+        s = HealthState()
+        server = HealthServer(s, port=0)
+        assert server.start() is True
+        try:
+            port = server._httpd.server_address[1]
+            base = f"http://127.0.0.1:{port}"
+            status, body = _get(base + "/ready")
+            assert status == 503
+            assert body == b"not ready\n"
+            s.mark_watching(watchdog_active=True)
+            s.mark_startup_scan_done()
+            status, body = _get(base + "/ready")
+            assert status == 200
+            assert body == b"ready\n"
+            status, body = _get(base + "/metrics")
+            assert b"state_mirror_ready 1" in body
+        finally:
+            server.stop()

--- a/ufm-state-mirror/tests/test_mirror.py
+++ b/ufm-state-mirror/tests/test_mirror.py
@@ -1,0 +1,233 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Unit tests for the mirror loop's bounded queues and delete reconcile (D2)."""
+
+import fnmatch
+
+from state_mirror.classifier import Classifier
+from state_mirror.mirror import Mirror
+from state_mirror.store import RedisStore
+
+UFM_VERSION = "7.0.1"
+WRITTEN_BY = "state-mirror:test"
+
+
+def _mirror(classifier, client, **kwargs):
+    return Mirror(classifier, RedisStore(client), UFM_VERSION, WRITTEN_BY, **kwargs)
+
+
+def _dir_classifier(root):
+    return Classifier.from_dict(
+        {
+            "entries": [
+                {
+                    "path": str(root),
+                    "handler": "directory",
+                    "redis_key_prefix": "ufm:cfg:sites:",
+                    "recursive": True,
+                }
+            ]
+        }
+    )
+
+
+def _blob_classifier(path):
+    return Classifier.from_dict(
+        {"entries": [{"path": str(path), "handler": "blob", "redis_key": "ufm:state:o"}]}
+    )
+
+
+class _FlakyPipe:
+    """Pipeline that raises on execute() when a delete op is present and the
+    backing client is in ``fail_delete`` mode (simulates a Redis outage)."""
+
+    def __init__(self, client):
+        self._client = client
+        self._ops = []
+
+    def set(self, key, value):
+        self._ops.append(("set", key, value))
+
+    def delete(self, key):
+        self._ops.append(("del", key))
+
+    def execute(self):
+        if self._client.fail_delete and any(op[0] == "del" for op in self._ops):
+            raise RuntimeError("simulated redis delete failure")
+        for op in self._ops:
+            if op[0] == "set":
+                self._client.store[op[1]] = op[2]
+            else:
+                self._client.store.pop(op[1], None)
+
+
+class FlakyRedis:
+    """FakeRedis whose deletes can be toggled to fail, for outage simulation."""
+
+    def __init__(self):
+        self.store = {}
+        self.fail_delete = False
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+    def pipeline(self, transaction=True):
+        return _FlakyPipe(self)
+
+    def keys(self, pattern):
+        return [k for k in self.store if fnmatch.fnmatch(k, pattern)]
+
+    def scan_iter(self, match=None, count=None):
+        pattern = match if match is not None else "*"
+        return iter([k for k in list(self.store) if fnmatch.fnmatch(k, pattern)])
+
+
+class TestQueueBounds:
+    def test_dirty_queue_is_bounded_by_entries(self, fake_redis, tmp_path):
+        m = _mirror(_blob_classifier(tmp_path / "o.conf"), fake_redis)
+        entry = m._handlers[0].entry
+        for _ in range(1000):
+            m._mark_dirty(entry)
+        # A set keyed by entry path collapses repeated marks to one.
+        assert len(m._dirty) == 1
+
+    def test_delete_queue_drops_oldest_when_full(self, fake_redis, tmp_path):
+        root = tmp_path / "sites"
+        root.mkdir()
+        m = _mirror(_dir_classifier(root), fake_redis, max_queue=3)
+        entry = m._handlers[0].entry
+        for i in range(10):
+            m._mark_delete(entry, str(root / f"f{i}"))
+        assert len(m._pending_deletes) == 3
+        assert m.state.dropped_events_total == 7
+        # The newest deletes are the ones retained (oldest dropped, O(1)).
+        keys = list(m._pending_deletes)
+        assert keys[-1] == "ufm:cfg:sites:f9"
+        assert "ufm:cfg:sites:f0" not in m._pending_deletes
+
+
+class TestDeleteReconcile:
+    def test_full_scan_flushes_observed_directory_delete(self, fake_redis, tmp_path):
+        root = tmp_path / "sites"
+        root.mkdir()
+        (root / "a").write_bytes(b"A")
+        (root / "b").write_bytes(b"B")
+        m = _mirror(_dir_classifier(root), fake_redis)
+        m.full_scan()
+        assert fake_redis.get("ufm:cfg:sites:a") == b"A"
+        assert fake_redis.get("ufm:cfg:sites:b") == b"B"
+
+        # Observed delete of b (unlink + mark); a later scan flushes it.
+        (root / "b").unlink()
+        m._mark_delete(m._handlers[0].entry, str(root / "b"))
+        m.full_scan()
+        assert fake_redis.get("ufm:cfg:sites:b") is None
+        assert fake_redis.get("ufm:cfg:sites:b:meta") is None
+        assert fake_redis.get("ufm:cfg:sites:a") == b"A"
+        assert not m._pending_deletes
+
+    def test_full_scan_flushes_observed_blob_delete(self, fake_redis, tmp_path):
+        f = tmp_path / "o.conf"
+        f.write_bytes(b"X")
+        m = _mirror(_blob_classifier(f), fake_redis)
+        m.full_scan()
+        assert fake_redis.get("ufm:state:o") == b"X"
+
+        f.unlink()
+        m._mark_delete(m._handlers[0].entry, str(f))
+        m.full_scan()
+        assert fake_redis.get("ufm:state:o") is None
+        assert not m._pending_deletes
+
+    def test_pending_delete_retried_until_backend_recovers(self, tmp_path):
+        f = tmp_path / "o.conf"
+        f.write_bytes(b"X")
+        client = FlakyRedis()
+        m = _mirror(_blob_classifier(f), client)
+        m.full_scan()
+        assert client.get("ufm:state:o") == b"X"
+
+        # Observed delete while the backend rejects deletes -> stays pending, kept.
+        f.unlink()
+        client.fail_delete = True
+        m._mark_delete(m._handlers[0].entry, str(f))
+        m.full_scan()
+        assert client.get("ufm:state:o") == b"X"
+        assert "ufm:state:o" in m._pending_deletes
+
+        # Backend recovers -> next scan flushes and clears pending.
+        client.fail_delete = False
+        m.full_scan()
+        assert client.get("ufm:state:o") is None
+        assert not m._pending_deletes
+
+
+class TestUnexpectedDelete:
+    def test_full_scan_counts_drift_and_keeps_key(self, fake_redis, tmp_path):
+        f = tmp_path / "o.conf"
+        f.write_bytes(b"X")
+        m = _mirror(_blob_classifier(f), fake_redis)
+        m.full_scan()
+        assert fake_redis.get("ufm:state:o") == b"X"
+
+        # File vanishes WITHOUT an observed delete -> drift.
+        f.unlink()
+        m.full_scan()
+        # Backend key is kept (it wins on ambiguity, HLD 5.3.7)...
+        assert fake_redis.get("ufm:state:o") == b"X"
+        # ...and the drift is surfaced exactly once.
+        assert m.state.unexpected_deletes_total == 1
+
+        # Persistent drift is not double-counted on the next scan.
+        m.full_scan()
+        assert m.state.unexpected_deletes_total == 1
+
+    def test_observed_delete_not_counted_as_drift(self, fake_redis, tmp_path):
+        f = tmp_path / "o.conf"
+        f.write_bytes(b"X")
+        m = _mirror(_blob_classifier(f), fake_redis)
+        m.full_scan()
+
+        # An *observed* delete is propagated and excluded from drift accounting.
+        f.unlink()
+        m._mark_delete(m._handlers[0].entry, str(f))
+        m.full_scan()
+        assert fake_redis.get("ufm:state:o") is None
+        assert m.state.unexpected_deletes_total == 0
+
+
+class TestDrainFailureKeepsPending:
+    def test_failed_event_delete_stays_pending(self, tmp_path):
+        f = tmp_path / "o.conf"
+        f.write_bytes(b"X")
+        client = FlakyRedis()
+        m = _mirror(_blob_classifier(f), client)
+        m.full_scan()
+
+        f.unlink()
+        client.fail_delete = True
+        m._mark_delete(m._handlers[0].entry, str(f))
+        m.drain_once(now=0.0, rate_limited=False)
+        # Delete failed during the "outage" -> not lost, retried next cycle.
+        assert "ufm:state:o" in m._pending_deletes
+        assert client.get("ufm:state:o") == b"X"
+
+        client.fail_delete = False
+        m.full_scan()
+        assert client.get("ufm:state:o") is None

--- a/ufm-state-mirror/tests/test_watcher.py
+++ b/ufm-state-mirror/tests/test_watcher.py
@@ -120,6 +120,30 @@ class TestMirrorEventHandler:
         )
         assert self.dirty == ["/opt/ufm/files/conf/pkey.conf"]
 
+    def test_moved_from_tracked_source_queues_delete(self):
+        # Renaming a tracked file away must drop its old key so a restore does
+        # not revive it (FIX-1). Destination is untracked -> no dirty mark.
+        self.handler.dispatch(
+            _evt(EVENT_MOVED, "/opt/ufm/files/conf/pkey.conf", "/opt/ufm/files/conf/pkey.conf.bak")
+        )
+        assert self.dirty == []
+        assert self.deletes == [("/opt/ufm/files/conf/pkey.conf", "/opt/ufm/files/conf/pkey.conf")]
+
+    def test_moved_child_within_directory_ships_dest_and_deletes_src(self):
+        # Renaming a child inside a watched dir ships the new name and drops the
+        # old child key (FIX-1).
+        self.handler.dispatch(
+            _evt(
+                EVENT_MOVED,
+                "/opt/ufm/files/conf/plugins/a.conf",
+                "/opt/ufm/files/conf/plugins/b.conf",
+            )
+        )
+        assert self.dirty == ["/opt/ufm/files/conf/plugins"]
+        assert self.deletes == [
+            ("/opt/ufm/files/conf/plugins", "/opt/ufm/files/conf/plugins/a.conf")
+        ]
+
     def test_deleted_marks_delete(self):
         self.handler.dispatch(_evt(EVENT_DELETED, "/opt/ufm/files/conf/plugins/a.conf"))
         assert self.deletes == [

--- a/ufm-state-mirror/tests/test_watcher.py
+++ b/ufm-state-mirror/tests/test_watcher.py
@@ -1,0 +1,225 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Unit tests for the watchdog change-detection layer (resolver + dispatch)
+and the event-driven drain on the mirror loop.
+"""
+
+import os
+from types import SimpleNamespace
+
+from state_mirror.classifier import Classifier, Entry
+from state_mirror.mirror import Mirror
+from state_mirror.store import RedisStore
+from state_mirror.watcher import (
+    EVENT_CLOSED,
+    EVENT_DELETED,
+    EVENT_MOVED,
+    MirrorEventHandler,
+    PathResolver,
+)
+
+UFM_VERSION = "7.0.1"
+WRITTEN_BY = "state-mirror:test"
+
+
+def _entries():
+    return [
+        Entry.from_dict(
+            {"path": "/opt/ufm/files/conf/pkey.conf", "handler": "blob", "redis_key": "ufm:pkey"}
+        ),
+        Entry.from_dict(
+            {
+                "path": "/opt/ufm/files/conf/plugins",
+                "handler": "directory",
+                "redis_key_prefix": "ufm:plugins:",
+                "recursive": True,
+            }
+        ),
+        Entry.from_dict(
+            {
+                "path": "/opt/ufm/files/conf/flat",
+                "handler": "directory",
+                "redis_key_prefix": "ufm:flat:",
+            }
+        ),
+    ]
+
+
+def _evt(event_type, src_path, dest_path=None, is_directory=False):
+    return SimpleNamespace(
+        event_type=event_type,
+        src_path=src_path,
+        dest_path=dest_path,
+        is_directory=is_directory,
+    )
+
+
+class TestPathResolver:
+    def setup_method(self):
+        self.resolver = PathResolver(_entries())
+
+    def test_single_file_exact_match(self):
+        e = self.resolver.resolve("/opt/ufm/files/conf/pkey.conf")
+        assert e is not None
+        assert e.redis_key == "ufm:pkey"
+
+    def test_recursive_directory_child(self):
+        e = self.resolver.resolve("/opt/ufm/files/conf/plugins/sub/a.conf")
+        assert e is not None
+        assert e.redis_key_prefix == "ufm:plugins:"
+
+    def test_nonrecursive_directory_direct_child(self):
+        e = self.resolver.resolve("/opt/ufm/files/conf/flat/a.conf")
+        assert e is not None
+        assert e.redis_key_prefix == "ufm:flat:"
+
+    def test_nonrecursive_directory_nested_child_is_ignored(self):
+        assert self.resolver.resolve("/opt/ufm/files/conf/flat/sub/a.conf") is None
+
+    def test_directory_object_itself_is_not_a_child(self):
+        assert self.resolver.resolve("/opt/ufm/files/conf/plugins") is None
+
+    def test_unknown_path(self):
+        assert self.resolver.resolve("/etc/passwd") is None
+
+    def test_watch_dirs_dedup_and_recursive(self):
+        d = dict(self.resolver.watch_dirs())
+        assert d["/opt/ufm/files/conf"] is False
+        assert "/opt/ufm/files/conf/plugins" in d
+        assert "/opt/ufm/files/conf/flat" in d
+
+
+class TestMirrorEventHandler:
+    def setup_method(self):
+        self.resolver = PathResolver(_entries())
+        self.dirty = []
+        self.deletes = []
+        self.handler = MirrorEventHandler(
+            self.resolver,
+            lambda entry: self.dirty.append(entry.path),
+            lambda entry, path: self.deletes.append((entry.path, path)),
+        )
+
+    def test_closed_marks_dirty(self):
+        self.handler.dispatch(_evt(EVENT_CLOSED, "/opt/ufm/files/conf/pkey.conf"))
+        assert self.dirty == ["/opt/ufm/files/conf/pkey.conf"]
+
+    def test_moved_uses_dest_path(self):
+        self.handler.dispatch(
+            _evt(EVENT_MOVED, "/opt/ufm/files/conf/.tmp", "/opt/ufm/files/conf/pkey.conf")
+        )
+        assert self.dirty == ["/opt/ufm/files/conf/pkey.conf"]
+
+    def test_deleted_marks_delete(self):
+        self.handler.dispatch(_evt(EVENT_DELETED, "/opt/ufm/files/conf/plugins/a.conf"))
+        assert self.deletes == [
+            ("/opt/ufm/files/conf/plugins", "/opt/ufm/files/conf/plugins/a.conf")
+        ]
+
+    def test_directory_event_ignored(self):
+        self.handler.dispatch(
+            _evt(EVENT_CLOSED, "/opt/ufm/files/conf/plugins/sub", is_directory=True)
+        )
+        assert self.dirty == []
+
+    def test_unknown_path_is_dropped(self):
+        self.handler.dispatch(_evt(EVENT_CLOSED, "/etc/passwd"))
+        assert self.dirty == []
+        assert self.deletes == []
+
+    def test_real_watchdog_event_objects(self):
+        import pytest
+
+        pytest.importorskip("watchdog.events")
+        from watchdog.events import FileClosedEvent, FileDeletedEvent, FileMovedEvent
+
+        self.handler.dispatch(FileClosedEvent("/opt/ufm/files/conf/pkey.conf"))
+        self.handler.dispatch(
+            FileMovedEvent("/opt/ufm/files/conf/.t", "/opt/ufm/files/conf/pkey.conf")
+        )
+        self.handler.dispatch(FileDeletedEvent("/opt/ufm/files/conf/plugins/a.conf"))
+        assert self.dirty == [
+            "/opt/ufm/files/conf/pkey.conf",
+            "/opt/ufm/files/conf/pkey.conf",
+        ]
+        assert self.deletes == [
+            ("/opt/ufm/files/conf/plugins", "/opt/ufm/files/conf/plugins/a.conf")
+        ]
+
+
+class TestDrain:
+    def _mirror(self, entries, client):
+        return Mirror(Classifier(entries), RedisStore(client), UFM_VERSION, WRITTEN_BY)
+
+    def test_dirty_drain_ships(self, fake_redis, tmp_path):
+        p = tmp_path / "pkey.conf"
+        p.write_bytes(b"v1")
+        entry = Entry.from_dict({"path": str(p), "handler": "blob", "redis_key": "ufm:pkey"})
+        m = self._mirror([entry], fake_redis)
+        m._mark_dirty(entry)
+        assert m.drain_once(now=0.0) == 1
+        assert fake_redis.get("ufm:pkey") == b"v1"
+        assert m.drain_once(now=10.0) == 0
+
+    def test_rate_limit_defers_then_ships(self, fake_redis, tmp_path):
+        p = tmp_path / "pkey.conf"
+        p.write_bytes(b"v1")
+        entry = Entry.from_dict(
+            {"path": str(p), "handler": "blob", "redis_key": "ufm:pkey", "rate_limit_ms": 100}
+        )
+        m = self._mirror([entry], fake_redis)
+        m._mark_dirty(entry)
+        assert m.drain_once(now=0.0) == 1
+        p.write_bytes(b"v2")
+        m._mark_dirty(entry)
+        assert m.drain_once(now=0.05) == 0
+        assert fake_redis.get("ufm:pkey") == b"v1"
+        assert m.drain_once(now=0.2) == 1
+        assert fake_redis.get("ufm:pkey") == b"v2"
+
+    def test_delete_drain_single_file(self, fake_redis, tmp_path):
+        p = tmp_path / "pkey.conf"
+        p.write_bytes(b"v1")
+        entry = Entry.from_dict({"path": str(p), "handler": "blob", "redis_key": "ufm:pkey"})
+        m = self._mirror([entry], fake_redis)
+        m._mark_dirty(entry)
+        m.drain_once(now=0.0)
+        assert fake_redis.get("ufm:pkey") == b"v1"
+        p.unlink()  # a real delete event means the file is actually gone
+        m._mark_delete(entry, str(p))
+        m.drain_once(now=1.0)
+        assert fake_redis.get("ufm:pkey") is None
+        assert fake_redis.get("ufm:pkey:meta") is None
+
+    def test_delete_drain_directory_child(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "a.conf").write_bytes(b"AAA")
+        entry = Entry.from_dict(
+            {"path": str(root), "handler": "directory", "redis_key_prefix": "ufm:plugins:"}
+        )
+        m = self._mirror([entry], fake_redis)
+        m._mark_dirty(entry)
+        m.drain_once(now=0.0)
+        assert fake_redis.get("ufm:plugins:a.conf") == b"AAA"
+        (root / "a.conf").unlink()  # real delete event -> file is actually gone
+        m._mark_delete(entry, str(root / "a.conf"))
+        m.drain_once(now=1.0)
+        assert fake_redis.get("ufm:plugins:a.conf") is None
+
+    def test_drain_skips_unknown_path(self, fake_redis):
+        m = self._mirror([], fake_redis)
+        with m._lock:
+            m._dirty.add("/nope")
+        assert m.drain_once(now=0.0) == 0
+        assert os.path.exists("/nope") is False


### PR DESCRIPTION
Final slice of the StateMirror sidecar (stacked on PR 3/4); completes the
component so the image is functional.

- mirror: the long-running sidecar loop -- watch (debounced) + periodic full
  scan, observed-delete reconcile (bounded, O(1) drop-oldest), unobserved
  drift kept-and-counted (backend wins on ambiguity), liveness heartbeat inside
  the scan/drain loops so a slow backend can't trip the probe and lose the
  emptyDir.
- restore: the one-shot init-container entrypoint (fail-closed).
- watcher: watchdog-based filesystem event handler + path resolution.
- health: readiness/liveness HTTP server and the Prometheus metric surface
  (backend-neutral names matching the chart's cross-repo contract).

After this PR the tree equals the original #373 branch.
Tests: full suite (mirror, watcher, health) green; ruff clean.

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug, please reference. For
Bug fixes why and what can be merged in a single item._

## How ?
_It is optional, but for complex PRs please provide information about the design,
architecture, approach, etc._

## Testing ?
_How was this feature tested? Did you add unit tests? Did you add E2E tests?_

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
