### PR TITLE
state-mirror: switch base image to ubuntu:24.04

### DIFF
--- a/ufm-state-mirror/build/Dockerfile
+++ b/ufm-state-mirror/build/Dockerfile
@@ -15,16 +15,20 @@
 #   restore (init):  python -m state_mirror.restore
 #   mirror (sidecar): python -m state_mirror.mirror
 
-# Base image: python:3.12-slim (Debian Bookworm), not an Ubuntu image. The
-# sidecar is stdlib-only (no Ubuntu/UFM-specific system packages or ABI), and
-# python:3.12-slim is the smallest official image carrying the exact Python
-# 3.12 runtime the engine targets -- smaller CVE/attack surface and image size
-# than ubuntu:22.04 + apt-installed Python. Revisit only if the sidecar ever
-# needs UFM/Ubuntu system libraries.
-FROM python:3.12-slim
+# UFM standardizes on Ubuntu; Noble ships the Python 3.12 the engine targets.
+# Deps install into /opt/venv (on PATH) to satisfy PEP 668 and keep `python` usable.
+FROM ubuntu:24.04
 
 ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1
+    PYTHONDONTWRITEBYTECODE=1 \
+    DEBIAN_FRONTEND=noninteractive \
+    PATH=/opt/venv/bin:$PATH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 python3-venv ca-certificates \
+    && python3 -m venv /opt/venv \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Switches the `ufm-state-mirror` image base from `python:3.12-slim` to `ubuntu:24.04` (Noble). Dependencies now install into a venv at `/opt/venv` (added to `PATH`); the entrypoints (`python -m state_mirror.mirror` / `state_mirror.restore`) are unchanged.

## Why ?

- **UFM alignment** — UFM standardizes on Ubuntu; this brings the sidecar image onto the same base family.
- **Python version** — Ubuntu 24.04 ships the Python 3.12 the engine targets in its default archive, so no deadsnakes PPA is required (unlike `ubuntu:22.04`, which only has 3.10).
- **CVE posture** — `python:3.12-slim` recently moved onto Debian 13 (trixie). A trivy scan (HIGH/CRITICAL) of identical builds:

  | Base | OS CVEs | Image size |
  |---|---|---|
  | `python:3.12-slim` (debian 13) | **2 CRITICAL + 9 HIGH** (perl — unused by the sidecar — plus sqlite/ncurses) | 183 MB |
  | `ubuntu:24.04` | **0 CRITICAL / 0 HIGH** | 205 MB |

  App-layer (Python deps) CVEs are identical between the two. Net trade: ~22 MB larger for a cleaner HIGH/CRITICAL profile and Ubuntu alignment.

## How ?

- `FROM ubuntu:24.04`, install `python3 python3-venv ca-certificates` with `--no-install-recommends`, create `/opt/venv`, and clean `apt` lists in the same layer.
- Put `/opt/venv/bin` on `PATH` so `pip install` runs inside the venv (satisfies PEP 668 / externally-managed) and `python` resolves into the venv — keeping the existing `ENTRYPOINT ["python", "-m"]` working with no chart changes.

## Testing ?

- Built `mellanox/ufm-state-mirror:1.0.0` on the new base (205 MB, Python 3.12.3).
- Smoke test inside the image: `state_mirror.{mirror,restore,health,watcher}` and native-wheel deps (`cryptography`/`cffi`, `kubernetes`, `redis`, `watchdog`, `yaml`) all import cleanly — confirming the venv-copy path carries the required shared libraries.
- trivy scan results as in the table above.