### PR TITLE
issue:5134987 [BugFix] [1/3] Enforce state mirror startup correctness

### DIFF
--- a/ufm-state-mirror/README.md
+++ b/ufm-state-mirror/README.md
@@ -72,9 +72,11 @@ The same image runs in two roles inside the UFM pod:
 ## Metrics
 
 - `state_mirror_ready` — 1 when ready.
-- `state_mirror_backend_reachable` — 1 if the storage backend was reachable on
-  the last op.
+- `state_mirror_backend_reachable` — 1 if the latest backend activity completed
+  without a recorded failure (a partial reconcile remains 0).
 - `state_mirror_watchdog_active` — 1 if the watchdog observer is running.
+- `state_mirror_poll_only_enabled` — 1 only when the internal, unsupported
+  poll-only readiness escape hatch was explicitly enabled.
 - `state_mirror_last_write_timestamp_seconds` — last successful store write.
 - `state_mirror_dirty_queue_depth`, `state_mirror_pending_deletes` — backlog.
 - `state_mirror_mirror_ops_total`, `state_mirror_full_scans_total`,
@@ -112,6 +114,7 @@ The Helm chart ships an optional `ServiceMonitor` + `PrometheusRule`
 | `UFM_VERSION` | `unknown` | Stamped into metadata. |
 | `STATE_MIRROR_METRICS_PORT` | `9180` | HTTP port. |
 | `STATE_MIRROR_MAX_QUEUE` | `100000` | Max observed-delete queue; drop-oldest on overflow (dropped deletes fall back to backend-wins, D2/HLD 8.2). |
+| `STATE_MIRROR_ALLOW_POLL_ONLY` | `false` | Internal unsupported escape hatch: permit readiness without watchdog after a clean reconcile; emits warnings and metrics. |
 | `STATE_MIRROR_BACKEND` | `configmap` | Install-wide storage backend: `configmap` (default, etcd-backed) or `redis` (BYO). Invalid values fail closed at startup. |
 | `STATE_MIRROR_LOG_LEVEL` | `INFO` | Log level. |
 | `STATE_MIRROR_LOG_TO_FILE` | `true` | Also log to `/opt/ufm/files/log/state_mirror.log`. |

--- a/ufm-state-mirror/README.md
+++ b/ufm-state-mirror/README.md
@@ -73,7 +73,8 @@ The same image runs in two roles inside the UFM pod:
 
 - `state_mirror_ready` — 1 when ready.
 - `state_mirror_backend_reachable` — 1 if the latest backend activity completed
-  without a recorded failure (a partial reconcile remains 0).
+  without a backend failure. Local filesystem errors fail reconciliation but do
+  not mark Redis or the Kubernetes API unreachable.
 - `state_mirror_watchdog_active` — 1 if the watchdog observer is running.
 - `state_mirror_poll_only_enabled` — 1 only when the internal, unsupported
   poll-only readiness escape hatch was explicitly enabled.

--- a/ufm-state-mirror/state_mirror/handlers/__init__.py
+++ b/ufm-state-mirror/state_mirror/handlers/__init__.py
@@ -14,7 +14,7 @@
 
 from state_mirror.classifier import Entry, Handler
 from state_mirror.handlers.atomic_blob import AtomicBlobHandler
-from state_mirror.handlers.base import BaseHandler
+from state_mirror.handlers.base import BaseHandler, MirrorResult
 from state_mirror.handlers.blob import BlobHandler
 from state_mirror.handlers.directory import DirectoryHandler
 from state_mirror.handlers.sqlite import SqliteHandler
@@ -42,6 +42,7 @@ def make_handler(entry: Entry, store, ufm_version: str, written_by: str) -> Base
 
 __all__ = [
     "BaseHandler",
+    "MirrorResult",
     "BlobHandler",
     "AtomicBlobHandler",
     "DirectoryHandler",

--- a/ufm-state-mirror/state_mirror/handlers/base.py
+++ b/ufm-state-mirror/state_mirror/handlers/base.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sqlite3
 import stat
 from dataclasses import dataclass
 from enum import Enum
@@ -34,6 +35,20 @@ from state_mirror.classifier import Baseline, Entry
 from state_mirror.store import Store
 
 log = logging.getLogger(__name__)
+
+
+def path_exists(path: str) -> bool:
+    """Check presence without hiding local inspection failures.
+
+    ``os.path.exists`` converts every ``OSError`` to ``False``. That is too
+    permissive for reconciliation: only true absence is a local no-op;
+    permission and I/O failures must propagate and keep startup fail-closed.
+    """
+    try:
+        os.stat(path)
+        return True
+    except FileNotFoundError:
+        return False
 
 
 class MirrorOutcome(str, Enum):
@@ -51,7 +66,9 @@ class MirrorResult:
     Counts make directory aggregation unambiguous: writes dominate successful
     reads, which dominate a purely local no-op. Failures are deliberately kept
     separate so a partially successful directory pass can advance the last
-    write timestamp while still leaving final backend reachability false.
+    write timestamp while still failing the reconcile. Only failures caused by
+    backend activity affect backend reachability; local filesystem and SQLite
+    failures remain fail-closed for startup without misreporting the backend.
     """
 
     writes: int = 0
@@ -73,6 +90,25 @@ class MirrorResult:
     @property
     def succeeded(self) -> bool:
         return not self.failures
+
+    @staticmethod
+    def failure_affects_backend(exc: BaseException) -> bool:
+        """Return whether ``exc`` invalidates backend health."""
+        return (
+            not isinstance(exc, (OSError, sqlite3.Error))
+            and getattr(exc, "reason", None) != "local_io"
+        )
+
+    @property
+    def backend_failures(self) -> tuple[BaseException, ...]:
+        """Failures that mean the storage operation did not complete.
+
+        Local filesystem and SQLite errors prevent a complete reconcile, but
+        they say nothing about Redis or the Kubernetes API. Unknown failures
+        remain backend-affecting conservatively so an unclassified store error
+        cannot be reported as healthy.
+        """
+        return tuple(exc for exc in self.failures if self.failure_affects_backend(exc))
 
     def plus(self, other: "MirrorResult") -> "MirrorResult":
         """Combine sibling operations while retaining every failure."""
@@ -139,7 +175,7 @@ class BaseHandler:
         unchanged file is a cheap backend read; a missing local file is a true
         local no-op and does not imply anything about backend reachability.
         """
-        if not os.path.exists(self.entry.path):
+        if not path_exists(self.entry.path):
             log.debug("mirror: %s does not exist yet, skipping", self.entry.path)
             return MirrorResult()
         body = self._read_file(self.entry.path)
@@ -181,7 +217,7 @@ class BaseHandler:
         ambiguity (the next restore re-materializes the file). An empty list means
         no drift.
         """
-        if os.path.exists(self.entry.path):
+        if path_exists(self.entry.path):
             return []
         if self.store.get_meta(self.entry.redis_key) is None:
             return []

--- a/ufm-state-mirror/state_mirror/handlers/base.py
+++ b/ufm-state-mirror/state_mirror/handlers/base.py
@@ -217,11 +217,15 @@ class BaseHandler:
         ambiguity (the next restore re-materializes the file). An empty list means
         no drift.
         """
+        return self.drift_scan()[0]
+
+    def drift_scan(self) -> tuple[list[str], int]:
+        """Return drift keys and the number of backend reads performed."""
         if path_exists(self.entry.path):
-            return []
+            return [], 0
         if self.store.get_meta(self.entry.redis_key) is None:
-            return []
-        return [self.entry.redis_key]
+            return [], 1
+        return [self.entry.redis_key], 1
 
     def _push_if_changed(self, key: str, body: bytes) -> bool:
         meta = self.store.get_meta(key)

--- a/ufm-state-mirror/state_mirror/handlers/base.py
+++ b/ufm-state-mirror/state_mirror/handlers/base.py
@@ -32,6 +32,7 @@ from typing import Optional
 
 from state_mirror import wire
 from state_mirror.classifier import Baseline, Entry
+from state_mirror.redis_errors import LOCAL_IO_REASON
 from state_mirror.store import Store
 
 log = logging.getLogger(__name__)
@@ -96,7 +97,7 @@ class MirrorResult:
         """Return whether ``exc`` invalidates backend health."""
         return (
             not isinstance(exc, (OSError, sqlite3.Error))
-            and getattr(exc, "reason", None) != "local_io"
+            and getattr(exc, "reason", None) != LOCAL_IO_REASON
         )
 
     @property

--- a/ufm-state-mirror/state_mirror/handlers/base.py
+++ b/ufm-state-mirror/state_mirror/handlers/base.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import logging
 import os
 import stat
+from dataclasses import dataclass
+from enum import Enum
 from typing import Optional
 
 from state_mirror import wire
@@ -32,6 +34,53 @@ from state_mirror.classifier import Baseline, Entry
 from state_mirror.store import Store
 
 log = logging.getLogger(__name__)
+
+
+class MirrorOutcome(str, Enum):
+    """Highest-precedence successful activity from one mirror pass."""
+
+    WROTE = "wrote"
+    READ_OK = "read_ok"
+    LOCAL_NOOP = "local_noop"
+
+
+@dataclass(frozen=True)
+class MirrorResult:
+    """Backend activity and failures produced by one handler pass.
+
+    Counts make directory aggregation unambiguous: writes dominate successful
+    reads, which dominate a purely local no-op. Failures are deliberately kept
+    separate so a partially successful directory pass can advance the last
+    write timestamp while still leaving final backend reachability false.
+    """
+
+    writes: int = 0
+    reads: int = 0
+    failures: tuple[BaseException, ...] = ()
+
+    @property
+    def outcome(self) -> MirrorOutcome:
+        if self.writes:
+            return MirrorOutcome.WROTE
+        if self.reads:
+            return MirrorOutcome.READ_OK
+        return MirrorOutcome.LOCAL_NOOP
+
+    @property
+    def backend_ops(self) -> int:
+        return self.writes + self.reads
+
+    @property
+    def succeeded(self) -> bool:
+        return not self.failures
+
+    def plus(self, other: "MirrorResult") -> "MirrorResult":
+        """Combine sibling operations while retaining every failure."""
+        return MirrorResult(
+            writes=self.writes + other.writes,
+            reads=self.reads + other.reads,
+            failures=self.failures + other.failures,
+        )
 
 
 class BaseHandler:
@@ -83,15 +132,16 @@ class BaseHandler:
             self.entry.baseline.value,
         )
 
-    def mirror(self) -> bool:
-        """Push the current file to Redis if it differs. Returns True if sent.
+    def mirror(self) -> MirrorResult:
+        """Push the current file to the store if it differs.
 
         Idempotent: compares the stored content hash before writing so an
-        unchanged file is a cheap no-op.
+        unchanged file is a cheap backend read; a missing local file is a true
+        local no-op and does not imply anything about backend reachability.
         """
         if not os.path.exists(self.entry.path):
             log.debug("mirror: %s does not exist yet, skipping", self.entry.path)
-            return False
+            return MirrorResult()
         body = self._read_file(self.entry.path)
         sent = self._push_if_changed(self.entry.redis_key, body)
         if sent:
@@ -101,7 +151,7 @@ class BaseHandler:
                 len(body),
                 self.entry.redis_key,
             )
-        return sent
+        return MirrorResult(writes=1) if sent else MirrorResult(reads=1)
 
     def on_delete(self) -> None:
         """Propagate a local delete to the store (HLD 5.3.9).

--- a/ufm-state-mirror/state_mirror/handlers/directory.py
+++ b/ufm-state-mirror/state_mirror/handlers/directory.py
@@ -24,7 +24,7 @@ import logging
 import os
 
 from state_mirror import wire
-from state_mirror.handlers.base import BaseHandler
+from state_mirror.handlers.base import BaseHandler, MirrorResult
 
 log = logging.getLogger(__name__)
 
@@ -41,11 +41,13 @@ class DirectoryHandler(BaseHandler):
             for dirpath, _dirs, files in os.walk(root):
                 for name in sorted(files):
                     full = os.path.join(dirpath, name)
+                    # Do not pre-stat here: _read_file_nofollow performs the
+                    # authoritative open/fstat and returns any inspection error
+                    # through MirrorResult instead of silently skipping a child.
                     yield os.path.relpath(full, root), full
         else:
-            # scandir reuses the stat already done by the OS (one syscall per
-            # entry instead of listdir + isfile). follow_symlinks=True keeps the
-            # prior os.path.isfile semantics: a symlink to a file still counts.
+            # Preserve the existing traversal behavior in the outcome-accounting
+            # change; symlink hardening is delivered by the next stacked PR.
             with os.scandir(root) as it:
                 for de in sorted(it, key=lambda e: e.name):
                     if de.is_file(follow_symlinks=True):
@@ -78,23 +80,24 @@ class DirectoryHandler(BaseHandler):
         real = os.path.realpath(dest)
         return real == root or real.startswith(root + os.sep)
 
-    def mirror(self) -> bool:
-        sent_any = False
+    def mirror(self) -> MirrorResult:
+        writes = 0
+        reads = 0
+        failures: list[BaseException] = []
         for relpath, full in self._iter_local_files():
-            # A local read error for one child (e.g. it vanished mid-scan) is
-            # skipped so the rest of the tree still mirrors. A backend error
-            # (WireError) is NOT swallowed -- it propagates so the caller records
-            # the outage via record_store_down instead of seeing a healthy run.
             try:
                 body = self._read_file(full)
-            except OSError:
-                log.exception("mirror: cannot read child %s; skipping", full)
+                key = self._key_for_rel(relpath)
+                if self._push_if_changed(key, body):
+                    log.info("mirror: shipped %s -> %s", full, key)
+                    writes += 1
+                else:
+                    reads += 1
+            except Exception as exc:
+                log.exception("mirror: child failed %s; continuing with siblings", full)
+                failures.append(exc)
                 continue
-            key = self._key_for_rel(relpath)
-            if self._push_if_changed(key, body):
-                log.info("mirror: shipped %s -> %s", full, key)
-                sent_any = True
-        return sent_any
+        return MirrorResult(writes=writes, reads=reads, failures=tuple(failures))
 
     def on_delete_child(self, relpath: str) -> None:
         log.info("on_delete_child: dropping %s", relpath)

--- a/ufm-state-mirror/state_mirror/handlers/directory.py
+++ b/ufm-state-mirror/state_mirror/handlers/directory.py
@@ -126,12 +126,17 @@ class DirectoryHandler(BaseHandler):
 
     def drift_keys(self) -> list[str]:
         """Per-child orphans: backend children with no local file (HLD 5.3.7)."""
+        return self.drift_scan()[0]
+
+    def drift_scan(self) -> tuple[list[str], int]:
+        """Return per-child drift after one backend-prefix enumeration."""
         local = {relpath for relpath, _full in self._iter_local_files()}
-        return [
+        drift = [
             self._key_for_rel(relpath)
             for relpath in self._iter_redis_relpaths()
             if relpath not in local
         ]
+        return drift, 1
 
     def bootstrap(self) -> None:
         # Directories have no single-file baseline; first-install is whatever

--- a/ufm-state-mirror/state_mirror/handlers/directory.py
+++ b/ufm-state-mirror/state_mirror/handlers/directory.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 import os
+import stat
 
 from state_mirror import wire
 from state_mirror.handlers.base import BaseHandler, MirrorResult
@@ -35,10 +36,14 @@ class DirectoryHandler(BaseHandler):
 
     def _iter_local_files(self):
         root = self.entry.path
-        if not os.path.isdir(root):
+        try:
+            root_stat = os.stat(root)
+        except FileNotFoundError:
             return
+        if not stat.S_ISDIR(root_stat.st_mode):
+            raise NotADirectoryError(f"classified directory path is not a directory: {root}")
         if self.entry.recursive:
-            for dirpath, _dirs, files in os.walk(root):
+            for dirpath, _dirs, files in os.walk(root, onerror=self._raise_walk_error):
                 for name in sorted(files):
                     full = os.path.join(dirpath, name)
                     # Do not pre-stat here: _read_file_nofollow performs the
@@ -52,6 +57,11 @@ class DirectoryHandler(BaseHandler):
                 for de in sorted(it, key=lambda e: e.name):
                     if de.is_file(follow_symlinks=True):
                         yield de.name, de.path
+
+    @staticmethod
+    def _raise_walk_error(exc: OSError) -> None:
+        """Make an unreadable recursive subtree fail reconciliation."""
+        raise exc
 
     def _iter_redis_relpaths(self):
         prefix = self.entry.redis_key_prefix
@@ -84,19 +94,22 @@ class DirectoryHandler(BaseHandler):
         writes = 0
         reads = 0
         failures: list[BaseException] = []
-        for relpath, full in self._iter_local_files():
-            try:
-                body = self._read_file(full)
-                key = self._key_for_rel(relpath)
-                if self._push_if_changed(key, body):
-                    log.info("mirror: shipped %s -> %s", full, key)
-                    writes += 1
-                else:
-                    reads += 1
-            except Exception as exc:
-                log.exception("mirror: child failed %s; continuing with siblings", full)
-                failures.append(exc)
-                continue
+        try:
+            for relpath, full in self._iter_local_files():
+                try:
+                    body = self._read_file(full)
+                    key = self._key_for_rel(relpath)
+                    if self._push_if_changed(key, body):
+                        log.info("mirror: shipped %s -> %s", full, key)
+                        writes += 1
+                    else:
+                        reads += 1
+                except Exception as exc:
+                    log.exception("mirror: child failed %s; continuing with siblings", full)
+                    failures.append(exc)
+        except Exception as exc:
+            log.exception("mirror: directory traversal failed for %s", self.entry.path)
+            failures.append(exc)
         return MirrorResult(writes=writes, reads=reads, failures=tuple(failures))
 
     def on_delete_child(self, relpath: str) -> None:

--- a/ufm-state-mirror/state_mirror/handlers/sqlite.py
+++ b/ufm-state-mirror/state_mirror/handlers/sqlite.py
@@ -38,7 +38,7 @@ import sqlite3
 import tempfile
 import time
 
-from state_mirror.handlers.base import BaseHandler
+from state_mirror.handlers.base import BaseHandler, MirrorResult
 
 log = logging.getLogger(__name__)
 
@@ -82,15 +82,11 @@ class SqliteHandler(BaseHandler):
         return int.from_bytes(header[_CHANGE_COUNTER_OFFSET:_HEADER_MIN_SIZE], "big")
 
     def signature(self) -> tuple[int, int, int]:
-        """A cheap change fingerprint: (header change counter, wal size, wal mtime).
-
-        Includes the ``-wal`` file because WAL-mode writes don't bump the header
-        change counter until a checkpoint.
-        """
+        """A cheap change fingerprint: (header change counter, wal size, wal mtime)."""
         cc = self.read_change_counter(self.entry.path)
         try:
-            st = os.stat(self._wal_path(self.entry.path))
-            return (cc, st.st_size, st.st_mtime_ns)
+            wal = os.stat(self._wal_path(self.entry.path))
+            return (cc, wal.st_size, wal.st_mtime_ns)
         except OSError:
             return (cc, -1, -1)
 
@@ -145,25 +141,25 @@ class SqliteHandler(BaseHandler):
             log.warning("could not remove temp file %s", path)
 
     # ---- mirror ------------------------------------------------------------
-    def mirror(self) -> bool:
+    def mirror(self) -> MirrorResult:
         # Each mirror() reports the snapshot cost only if it actually snapshots.
         self.last_snapshot_seconds = None
         if not os.path.exists(self.entry.path):
             log.debug("mirror: sqlite db %s does not exist yet, skipping", self.entry.path)
-            return False
+            return MirrorResult()
         try:
             size = os.path.getsize(self.entry.path)
         except OSError as exc:
-            log.warning("mirror: cannot stat %s: %s; skipping", self.entry.path, exc)
-            return False
+            log.warning("mirror: cannot stat %s: %s", self.entry.path, exc)
+            raise
         if size == 0:
             log.debug("mirror: sqlite db %s is empty, skipping", self.entry.path)
-            return False
+            return MirrorResult()
         # Cheap change fingerprint first: skip the O(DB-size) online backup when
         # the DB is unchanged since the last successful ship (HLD 5.3.4).
         sig = self.signature()
         if sig == self._last_shipped_sig:
-            return False
+            return MirrorResult()
         body = self.snapshot_bytes()
         sent = self._push_if_changed(self.entry.redis_key, body)
         # The snapshot at this signature is now persisted (or byte-identical to
@@ -176,7 +172,7 @@ class SqliteHandler(BaseHandler):
                 len(body),
                 self.entry.redis_key,
             )
-        return sent
+        return MirrorResult(writes=1) if sent else MirrorResult(reads=1)
 
     # ---- restore -----------------------------------------------------------
     def restore(self) -> bool:

--- a/ufm-state-mirror/state_mirror/handlers/sqlite.py
+++ b/ufm-state-mirror/state_mirror/handlers/sqlite.py
@@ -38,7 +38,7 @@ import sqlite3
 import tempfile
 import time
 
-from state_mirror.handlers.base import BaseHandler, MirrorResult
+from state_mirror.handlers.base import BaseHandler, MirrorResult, path_exists
 
 log = logging.getLogger(__name__)
 
@@ -68,14 +68,11 @@ class SqliteHandler(BaseHandler):
 
     @staticmethod
     def read_change_counter(path: str) -> int:
-        """Return the DB header's file_change_counter (0 if unreadable)."""
+        """Return the DB header change counter, using 0 only for absence/short data."""
         try:
             with open(path, "rb") as f:
                 header = f.read(_HEADER_MIN_SIZE)
         except FileNotFoundError:
-            return 0
-        except OSError as exc:
-            log.warning("change-counter read of %s failed: %s; treating as unchanged", path, exc)
             return 0
         if len(header) < _HEADER_MIN_SIZE:
             return 0
@@ -87,7 +84,7 @@ class SqliteHandler(BaseHandler):
         try:
             wal = os.stat(self._wal_path(self.entry.path))
             return (cc, wal.st_size, wal.st_mtime_ns)
-        except OSError:
+        except FileNotFoundError:
             return (cc, -1, -1)
 
     @staticmethod
@@ -144,7 +141,7 @@ class SqliteHandler(BaseHandler):
     def mirror(self) -> MirrorResult:
         # Each mirror() reports the snapshot cost only if it actually snapshots.
         self.last_snapshot_seconds = None
-        if not os.path.exists(self.entry.path):
+        if not path_exists(self.entry.path):
             log.debug("mirror: sqlite db %s does not exist yet, skipping", self.entry.path)
             return MirrorResult()
         try:

--- a/ufm-state-mirror/state_mirror/health.py
+++ b/ufm-state-mirror/state_mirror/health.py
@@ -50,12 +50,20 @@ BACKEND_ERROR_REASONS: tuple[str, ...] = tuple(
 
 
 class HealthState:
-    """Mutable, thread-safe view of the sidecar's health and counters."""
+    """Mutable, thread-safe view of sidecar health and counters.
 
-    def __init__(self):
+    Startup readiness latches only after a successful initial reconcile and
+    either all required watchers are armed or the explicit poll-only escape
+    hatch is enabled. Once latched, later runtime degradation is reported by
+    the backend/watchdog gauges without withdrawing pod readiness.
+    """
+
+    def __init__(self, *, allow_poll_only: bool = False):
         self._lock = threading.Lock()
-        self.watching_started = False
-        self.startup_scan_done = False
+        self.initial_reconcile_ok = False
+        self.required_watchers_armed = False
+        self.allow_poll_only = allow_poll_only
+        self.readiness_latched = False
         self.watchdog_active = False
         self.loop_started = False
         self.last_loop_tick = 0.0
@@ -72,14 +80,27 @@ class HealthState:
         # Last snapshot wall-clock per SQLite DB (basename label), HLD 5.3.4.
         self.snapshot_durations: dict[str, float] = {}
 
-    def mark_watching(self, watchdog_active: bool) -> None:
+    def mark_watching(
+        self, watchdog_active: bool, *, all_required_armed: bool | None = None
+    ) -> None:
+        """Record observer state and re-evaluate the startup readiness gate."""
         with self._lock:
-            self.watching_started = True
             self.watchdog_active = watchdog_active
+            self.required_watchers_armed = (
+                watchdog_active if all_required_armed is None else all_required_armed
+            )
+            self._maybe_latch_ready()
 
-    def mark_startup_scan_done(self) -> None:
+    def mark_initial_reconcile(self, succeeded: bool) -> None:
+        """Record the latest startup reconcile result and evaluate readiness."""
         with self._lock:
-            self.startup_scan_done = True
+            self.initial_reconcile_ok = succeeded
+            self._maybe_latch_ready()
+
+    def _maybe_latch_ready(self) -> None:
+        watcher_gate = self.required_watchers_armed or self.allow_poll_only
+        if self.initial_reconcile_ok and watcher_gate:
+            self.readiness_latched = True
 
     def tick(self, dirty_depth: int, pending_deletes: int) -> None:
         with self._lock:
@@ -101,7 +122,11 @@ class HealthState:
             self.loop_started = True
             self.last_loop_tick = time.monotonic()
 
-    def record_store_ok(self) -> None:
+    def record_read_ok(self) -> None:
+        with self._lock:
+            self.backend_reachable = True
+
+    def record_write_ok(self) -> None:
         with self._lock:
             self.backend_reachable = True
             self.last_store_write = time.time()
@@ -112,6 +137,11 @@ class HealthState:
             if reason not in self.backend_errors:
                 reason = "other"
             self.backend_errors[reason] += 1
+
+    def mark_backend_unreachable(self) -> None:
+        """Make a previously counted failure win final aggregate reachability."""
+        with self._lock:
+            self.backend_reachable = False
 
     def add_mirror_ops(self, n: int) -> None:
         with self._lock:
@@ -146,7 +176,7 @@ class HealthState:
 
     def is_ready(self) -> bool:
         with self._lock:
-            return self.watching_started and self.startup_scan_done
+            return self.readiness_latched
 
     def is_alive(self, now: float | None = None, timeout: float = LIVENESS_TIMEOUT_S) -> bool:
         if now is None:
@@ -183,11 +213,16 @@ def render_metrics(state: HealthState) -> str:
 
     # Derive readiness from the same snapshot (not a second is_ready() lock) so
     # the gauge is consistent with the rest of this scrape.
-    ready = snap["watching_started"] and snap["startup_scan_done"]
+    ready = snap["readiness_latched"]
     gauge("state_mirror_ready", "1 if the sidecar is ready", int(ready))
     gauge(
+        "state_mirror_poll_only_enabled",
+        "1 if the unsupported poll-only readiness escape hatch is enabled",
+        int(snap["allow_poll_only"]),
+    )
+    gauge(
         "state_mirror_backend_reachable",
-        "1 if the storage backend was reachable on the last op",
+        "1 if the latest backend activity completed without a recorded failure",
         int(snap["backend_reachable"]),
     )
     gauge(
@@ -209,8 +244,8 @@ def render_metrics(state: HealthState) -> str:
     counter("state_mirror_events_total", "Total watchdog change/delete marks", snap["events_total"])
     counter(
         "state_mirror_dropped_events_total",
-        "Delete marks dropped from a full bounded queue (D2 drop policy); "
-        "recovered by the next full-scan delete reconcile",
+        "Delete marks dropped from a full bounded queue; backend copies remain "
+        "and deleted files are recreated on restore unless removed manually",
         snap["dropped_events_total"],
     )
     counter(

--- a/ufm-state-mirror/state_mirror/health.py
+++ b/ufm-state-mirror/state_mirror/health.py
@@ -132,8 +132,18 @@ class HealthState:
             self.last_store_write = time.time()
 
     def record_store_down(self, reason: str = "other") -> None:
+        self.record_error(reason, backend_unreachable=True)
+
+    def record_error(self, reason: str = "other", *, backend_unreachable: bool) -> None:
+        """Count a mirror failure and optionally mark the backend unavailable.
+
+        Local I/O errors remain visible in the existing classified counter but
+        must not fire the backend-unreachable signal. They still fail the
+        startup reconcile through ``MirrorResult.succeeded``.
+        """
         with self._lock:
-            self.backend_reachable = False
+            if backend_unreachable:
+                self.backend_reachable = False
             if reason not in self.backend_errors:
                 reason = "other"
             self.backend_errors[reason] += 1
@@ -222,7 +232,7 @@ def render_metrics(state: HealthState) -> str:
     )
     gauge(
         "state_mirror_backend_reachable",
-        "1 if the latest backend activity completed without a recorded failure",
+        "1 if the latest backend activity completed without a backend failure",
         int(snap["backend_reachable"]),
     )
     gauge(

--- a/ufm-state-mirror/state_mirror/mirror.py
+++ b/ufm-state-mirror/state_mirror/mirror.py
@@ -320,31 +320,25 @@ class Mirror:
             pending = set(self._pending_deletes)
             known_at_start = set(self._known_drift)
         current: set[str] = set()
-        present_paths: set[str] = set()
         failures: list[BaseException] = []
         reads = 0
         for handler in self._handlers:
             self.state.heartbeat()
             try:
-                # Single-file handlers short-circuit locally when the file is
-                # present; directories always enumerate their backend prefix.
-                # Count only real backend reads so startup still probes when a
-                # scan consisted entirely of local no-ops.
-                local_exists = path_exists(handler.entry.path)
-                if local_exists:
-                    present_paths.add(handler.entry.path)
-                reads_backend = handler.entry.is_directory or not local_exists
-                current.update(handler.drift_keys())
+                # The handler reports actual backend activity; inferring it from
+                # path presence is racy when a file appears during the scan.
+                handler_drift, backend_reads = handler.drift_scan()
+                current.update(handler_drift)
                 if (
                     isinstance(handler, SqliteHandler)
                     and handler.entry.redis_key in known_at_start
-                    and not local_exists
+                    and not path_exists(handler.entry.path)
                 ):
                     # Observed SQLite deletion is an operator-error onset even
                     # when no durable snapshot exists. Do not count it again
                     # until the DB actually reappears.
                     current.add(handler.entry.redis_key)
-                reads += int(reads_backend)
+                reads += backend_reads
             except Exception as exc:
                 reason = _reason(exc)
                 log.exception("drift check failed for %s [%s]", handler.entry.path, reason)
@@ -359,6 +353,7 @@ class Mirror:
                     key for key in known_at_start if self._key_belongs_to_handler(key, handler)
                 )
         current -= pending
+        final_presence_errors: list[BaseException] = []
         with self._lock:
             # Watchdog callbacks may add a SQLite onset or clear one on local
             # reappearance while this backend scan is running. Merge additions
@@ -366,14 +361,28 @@ class Mirror:
             current |= self._known_drift - known_at_start
             current -= known_at_start - self._known_drift
             for handler in self._handlers:
-                if (
-                    isinstance(handler, SqliteHandler)
-                    and handler.entry.redis_key
-                    and handler.entry.path in present_paths
-                ):
+                if not isinstance(handler, SqliteHandler) or not handler.entry.redis_key:
+                    continue
+                try:
+                    present = path_exists(handler.entry.path)
+                except OSError as exc:
+                    final_presence_errors.append(exc)
+                    # Presence is unknown: preserve the latest onset state,
+                    # including a watchdog update that arrived during the scan.
+                    if handler.entry.redis_key in self._known_drift:
+                        current.add(handler.entry.redis_key)
+                    else:
+                        current.discard(handler.entry.redis_key)
+                    continue
+                if present:
                     current.discard(handler.entry.redis_key)
             new_drift = current - self._known_drift
             self._known_drift = current
+        for exc in final_presence_errors:
+            reason = _reason(exc)
+            log.exception("final SQLite presence check failed [%s]", reason, exc_info=exc)
+            self.state.record_error(reason, backend_unreachable=False)
+            failures.append(exc)
         if new_drift:
             log.warning(
                 "drift: %d object(s) present in backend but missing locally; "

--- a/ufm-state-mirror/state_mirror/mirror.py
+++ b/ufm-state-mirror/state_mirror/mirror.py
@@ -28,9 +28,10 @@ import os
 import threading
 import time
 from collections import OrderedDict
+from contextlib import suppress
 
 from state_mirror.classifier import Classifier, Entry, Handler
-from state_mirror.handlers import make_handler
+from state_mirror.handlers import MirrorResult, make_handler
 from state_mirror.handlers.sqlite import SqliteHandler
 from state_mirror.health import DEFAULT_PORT, HealthServer, HealthState
 from state_mirror.redis_errors import classify_redis_error
@@ -83,9 +84,10 @@ class Mirror:
         # drift, never a delete (HLD 5.3.7/5.3.9, "the backend wins on ambiguity").
         self._pending_deletes: OrderedDict[str, tuple[str, str]] = OrderedDict()
         self._max_queue = max(1, max_queue)
-        # Keys already counted as unobserved drift (file gone but backend has it),
-        # so persistent drift bumps state_mirror_unexpected_delete_total once per
-        # onset rather than every scan (HLD 5.3.7).
+        # Keys already counted as missing-local drift. Usually the backend still
+        # has the object; an observed SQLite deletion is retained here even if
+        # its backend snapshot is absent, because only local reappearance ends
+        # that operator-error onset (HLD 5.3.7/5.3.9).
         self._known_drift: set[str] = set()
         self._last_ship: dict[str, float] = {}
         self._wakeup = threading.Event()
@@ -97,6 +99,8 @@ class Mirror:
     def _mark_dirty(self, entry: Entry) -> None:
         with self._lock:
             self._dirty.add(entry.path)
+            if entry.handler is Handler.SQLITE and entry.redis_key and os.path.exists(entry.path):
+                self._known_drift.discard(entry.redis_key)
         self.state.inc_events()
         self._wakeup.set()
 
@@ -105,6 +109,28 @@ class Mirror:
         if handler is None:
             return
         key = handler.key_for_fs_path(fs_path)
+        if isinstance(handler, SqliteHandler):
+            if os.path.exists(fs_path):
+                # The delete event raced with DB recreation. Mirror the current
+                # file, but do not open an unexpected-delete onset.
+                with self._lock:
+                    self._dirty.add(entry.path)
+                    self._known_drift.discard(key)
+                self.state.inc_events()
+                self._wakeup.set()
+                return
+            with self._lock:
+                new_onset = key not in self._known_drift
+                self._known_drift.add(key)
+            log.error(
+                "sqlite database deleted locally; retaining backend snapshot for restore: %s",
+                entry.path,
+            )
+            if new_onset:
+                self.state.inc_unexpected_deletes()
+            self.state.inc_events()
+            self._wakeup.set()
+            return
         dropped = 0
         with self._lock:
             # Collapse duplicate observations of the same key; keep it newest.
@@ -139,6 +165,7 @@ class Mirror:
             dirty = list(self._dirty)
             self._dirty = set()
         ops = 0
+        aggregate = MirrorResult()
         requeue: set[str] = set()
         for path in dirty:
             self.state.heartbeat()
@@ -154,36 +181,41 @@ class Mirror:
             ):
                 requeue.add(path)
                 continue
-            try:
-                if handler.mirror():
-                    ops += 1
-                self._last_ship[path] = now
-                self.state.record_store_ok()
-            except Exception as exc:
-                reason = _reason(exc)
-                log.exception("event mirror failed for %s [%s]; will retry", path, reason)
-                self.state.record_store_down(reason)
+            result = self._mirror_handler(handler)
+            self._record_result(result)
+            aggregate = aggregate.plus(result)
+            ops += result.writes
+            if result.failures:
+                log.error("event mirror failed for %s; will retry", path)
                 requeue.add(path)
+            else:
+                self._last_ship[path] = now
         if requeue:
             with self._lock:
                 self._dirty |= requeue
-        ops += self.flush_pending_deletes()
+        deleted = self.flush_pending_deletes()
+        aggregate = aggregate.plus(deleted)
+        ops += deleted.writes
+        if aggregate.failures:
+            self.state.mark_backend_unreachable()
         if ops:
             self.state.add_mirror_ops(ops)
         return ops
 
-    def flush_pending_deletes(self) -> int:
+    def flush_pending_deletes(self) -> MirrorResult:
         """Propagate observed deletes to the backend; retry the ones that failed.
 
         Only keys the sidecar actually observed being deleted are in
         ``_pending_deletes``, so this never removes a backend object for a file
         that merely went missing unobserved (that is drift -- see
         :meth:`_scan_unexpected_deletes`). A delete whose file reappeared before
-        we propagated it is dropped (no longer a delete). Returns ops applied.
+        we propagated it is dropped (no longer a delete). The result preserves
+        successful deletes and failures separately for aggregate health.
         """
         with self._lock:
             items = list(self._pending_deletes.items())
-        ops = 0
+        writes = 0
+        failures: list[BaseException] = []
         for key, (entry_path, fs_path) in items:
             self.state.heartbeat()
             if os.path.exists(fs_path):
@@ -194,13 +226,14 @@ class Mirror:
                 self._apply_delete(entry_path, fs_path)
                 with self._lock:
                     self._pending_deletes.pop(key, None)
-                ops += 1
-                self.state.record_store_ok()
+                writes += 1
+                self.state.record_write_ok()
             except Exception as exc:
                 reason = _reason(exc)
                 log.exception("delete failed for %s [%s]; will retry next cycle", key, reason)
                 self.state.record_store_down(reason)
-        return ops
+                failures.append(exc)
+        return MirrorResult(writes=writes, failures=tuple(failures))
 
     def _apply_delete(self, entry_path: str, fs_path: str) -> None:
         handler = self._by_path.get(entry_path)
@@ -211,56 +244,99 @@ class Mirror:
         else:
             handler.on_delete()
 
-    def full_scan(self) -> int:
-        """Mirror every entry whose body differs from the store. Returns #sent.
+    def full_scan(self) -> MirrorResult:
+        """Mirror every entry and report all work and failures.
 
         Also retries any observed-but-unpropagated deletes and accounts for
         unobserved drift (HLD 5.3.7). Heartbeats per entry so a slow backend can
         extend the scan without tripping the liveness probe.
         """
-        sent = 0
+        aggregate = MirrorResult()
         for handler in self._handlers:
             self.state.heartbeat()
-            try:
-                if handler.mirror():
-                    sent += 1
-                self.state.record_store_ok()
-            except Exception as exc:
-                reason = _reason(exc)
-                log.exception("mirror failed for %s [%s]", handler.entry.path, reason)
-                self.state.record_store_down(reason)
+            result = self._mirror_handler(handler)
+            self._record_result(result)
+            aggregate = aggregate.plus(result)
         flushed = self.flush_pending_deletes()
-        self._scan_unexpected_deletes()
+        aggregate = aggregate.plus(flushed)
+        aggregate = aggregate.plus(self._scan_unexpected_deletes())
+        if aggregate.failures:
+            # Successful siblings may have followed a failed operation. Preserve
+            # their write/read accounting, but let any failure win final
+            # reachability for this aggregate reconcile.
+            self.state.mark_backend_unreachable()
+        elif aggregate.reads:
+            # Drift enumeration is itself a backend read. This matters when all
+            # local entries were no-ops: a successful scan must clear a prior
+            # outage even though no handler read or wrote an object body.
+            self.state.record_read_ok()
         self.state.inc_full_scans()
-        total = sent + flushed
-        if total:
-            self.state.add_mirror_ops(total)
-        return sent
+        if aggregate.writes:
+            self.state.add_mirror_ops(aggregate.writes)
+        return aggregate
 
-    def _scan_unexpected_deletes(self) -> int:
+    def _scan_unexpected_deletes(self) -> MirrorResult:
         """Count keys present in the backend whose local file vanished (HLD 5.3.7).
 
         Does not delete anything (the backend wins on ambiguity); only bumps
         ``state_mirror_unexpected_delete_total`` for keys newly entering drift, so
         the gap is visible instead of silent. Keys with an observed delete still
         pending propagation are excluded -- those are intended deletes, not drift.
-        Returns the number of newly-drifted keys. Reads only, so it never updates
-        the last-write timestamp (which would mask mirror lag).
+        Reads only, so it never updates the last-write timestamp (which would
+        mask mirror lag).
         """
         with self._lock:
             pending = set(self._pending_deletes)
+            known_at_start = set(self._known_drift)
         current: set[str] = set()
+        failures: list[BaseException] = []
+        reads = 0
         for handler in self._handlers:
             self.state.heartbeat()
             try:
+                # Single-file handlers short-circuit locally when the file is
+                # present; directories always enumerate their backend prefix.
+                # Count only real backend reads so startup still probes when a
+                # scan consisted entirely of local no-ops.
+                reads_backend = handler.entry.is_directory or not os.path.exists(handler.entry.path)
                 current.update(handler.drift_keys())
+                if (
+                    isinstance(handler, SqliteHandler)
+                    and handler.entry.redis_key in known_at_start
+                    and not os.path.exists(handler.entry.path)
+                ):
+                    # Observed SQLite deletion is an operator-error onset even
+                    # when no durable snapshot exists. Do not count it again
+                    # until the DB actually reappears.
+                    current.add(handler.entry.redis_key)
+                reads += int(reads_backend)
             except Exception as exc:
                 reason = _reason(exc)
                 log.exception("drift check failed for %s [%s]", handler.entry.path, reason)
                 self.state.record_store_down(reason)
+                failures.append(exc)
+                # A failed scope is unknown, not healthy. Retain its previous
+                # drift-onset state so a transient outage cannot double-count
+                # the same missing SQLite DB on the next successful scan.
+                current.update(
+                    key for key in known_at_start if self._key_belongs_to_handler(key, handler)
+                )
         current -= pending
-        new_drift = current - self._known_drift
-        self._known_drift = current
+        with self._lock:
+            # Watchdog callbacks may add a SQLite onset or clear one on local
+            # reappearance while this backend scan is running. Merge additions
+            # and honor removals so the scan cannot overwrite newer event state.
+            current |= self._known_drift - known_at_start
+            current -= known_at_start - self._known_drift
+            for handler in self._handlers:
+                if (
+                    isinstance(handler, SqliteHandler)
+                    and handler.entry.redis_key
+                    and os.path.exists(handler.entry.path)
+                ):
+                    current.discard(handler.entry.redis_key)
+            new_drift = current - self._known_drift
+            self._known_drift = current
         if new_drift:
             log.warning(
                 "drift: %d object(s) present in backend but missing locally; "
@@ -269,11 +345,18 @@ class Mirror:
                 sorted(new_drift),
             )
             self.state.inc_unexpected_deletes(len(new_drift))
-        return len(new_drift)
+        return MirrorResult(reads=reads, failures=tuple(failures))
+
+    @staticmethod
+    def _key_belongs_to_handler(key: str, handler) -> bool:
+        if handler.entry.is_directory:
+            return key.startswith(handler.entry.redis_key_prefix)
+        return key == handler.entry.redis_key
 
     def poll_sqlite(self, now: float | None = None) -> int:
         now = time.monotonic() if now is None else now
         sent = 0
+        aggregate = MirrorResult()
         for handler in self._handlers:
             if handler.entry.handler is not Handler.SQLITE or not isinstance(
                 handler, SqliteHandler
@@ -288,36 +371,123 @@ class Mirror:
                 continue
             self._sql_last_poll[path] = now
             self.state.heartbeat()
-            try:
-                # mirror() self-gates on the WAL-aware fingerprint, so an idle DB
-                # is just a cheap header read; only an actual change snapshots.
-                if handler.mirror():
-                    sent += 1
-                if handler.last_snapshot_seconds is not None:
-                    self.state.set_snapshot_duration(
-                        os.path.basename(path), handler.last_snapshot_seconds
-                    )
-                self.state.record_store_ok()
-            except Exception as exc:
-                reason = _reason(exc)
-                log.exception("sqlite snapshot failed for %s [%s]", path, reason)
-                self.state.record_store_down(reason)
+            result = self._mirror_handler(handler)
+            self._record_result(result)
+            aggregate = aggregate.plus(result)
+            sent += result.writes
+            if handler.last_snapshot_seconds is not None:
+                self.state.set_snapshot_duration(
+                    os.path.basename(path), handler.last_snapshot_seconds
+                )
         if sent:
             self.state.add_mirror_ops(sent)
+        if aggregate.failures:
+            self.state.mark_backend_unreachable()
         return sent
 
-    def start_watching(self) -> None:
-        """Arm the watchdog observer. Fail-soft: poll-only if it can't start."""
+    def _mirror_handler(self, handler) -> MirrorResult:
         try:
-            self._observer = build_observer(self._resolver, self._event_handler)
-            self._observer.start()
-            log.info("watchdog observer started")
-            self.state.mark_watching(watchdog_active=True)
-        except Exception:
-            log.exception("watchdog observer failed to start; running poll-only")
-            self.state.mark_watching(watchdog_active=False)
+            return handler.mirror()
+        except Exception as exc:
+            reason = _reason(exc)
+            log.exception("mirror failed for %s [%s]", handler.entry.path, reason)
+            return MirrorResult(failures=(exc,))
 
-    def run_forever(self, scan_interval_s: float = 60.0, poll_interval_s: float = 0.5) -> None:
+    def _record_result(self, result: MirrorResult) -> None:
+        """Apply WROTE > READ_OK > LOCAL_NOOP, then let failures win."""
+        if result.writes:
+            self.state.record_write_ok()
+        elif result.reads:
+            self.state.record_read_ok()
+        for exc in result.failures:
+            self.state.record_store_down(_reason(exc))
+
+    def _cleanup_observer(self, observer) -> None:
+        with suppress(Exception):
+            observer.stop()
+        with suppress(RuntimeError, AttributeError):
+            observer.join(timeout=5.0)
+
+    @staticmethod
+    def _observer_healthy(observer) -> bool:
+        """Require the dispatcher and every scheduled emitter to be alive."""
+        if observer is None or not observer.is_alive():
+            return False
+        emitters = getattr(observer, "emitters", None)
+        return emitters is None or all(emitter.is_alive() for emitter in emitters)
+
+    def start_watching(self) -> bool:
+        """Arm every required watchdog watch; return whether strict setup passed."""
+        try:
+            setup = build_observer(self._resolver, self._event_handler)
+            if not setup.complete:
+                for exc in setup.failures:
+                    log.error("required watchdog setup failed: %s", exc)
+                self.state.mark_watching(False, all_required_armed=False)
+                return False
+            observer = setup.observer
+            observer.start()
+            if not self._observer_healthy(observer):
+                raise RuntimeError("watchdog observer or required emitter did not become active")
+            self._observer = observer
+            log.info("watchdog observer started")
+            self.state.mark_watching(True, all_required_armed=True)
+            return True
+        except Exception:
+            log.exception("watchdog observer failed to start")
+            if "observer" in locals():
+                self._cleanup_observer(observer)
+            self._observer = None
+            self.state.mark_watching(False, all_required_armed=False)
+            return False
+
+    def startup_once(self) -> bool:
+        """Attempt watcher setup plus one fail-closed startup reconcile.
+
+        Clear the reconcile gate first: a watcher recovered from an earlier
+        attempt must not combine with that attempt's successful scan and expose
+        readiness before the current scan has completed.
+        """
+        self.state.mark_initial_reconcile(False)
+        watchers_ok = self._observer_healthy(self._observer)
+        if not watchers_ok and self._observer is not None:
+            self._cleanup_observer(self._observer)
+            self._observer = None
+            self.state.mark_watching(False, all_required_armed=False)
+        if watchers_ok:
+            self.state.mark_watching(True, all_required_armed=True)
+        if not watchers_ok:
+            watchers_ok = self.start_watching()
+        result = self.full_scan()
+        if result.succeeded and result.backend_ops == 0:
+            try:
+                self.store.probe()
+                self.state.record_read_ok()
+                result = result.plus(MirrorResult(reads=1))
+            except Exception as exc:
+                log.exception("startup backend probe failed")
+                self.state.record_store_down(_reason(exc))
+                result = result.plus(MirrorResult(failures=(exc,)))
+
+        # The initial reconcile can be slow. Recheck after it completes so an
+        # observer that died during the scan cannot satisfy strict readiness.
+        watchers_ok = self._observer_healthy(self._observer)
+        if not watchers_ok and self._observer is not None:
+            self._cleanup_observer(self._observer)
+            self._observer = None
+        self.state.mark_watching(watchers_ok, all_required_armed=watchers_ok)
+        if not watchers_ok and self.state.allow_poll_only:
+            log.warning("UNSUPPORTED poll-only mode enabled; readiness may pass without watchdog")
+        watcher_gate = watchers_ok or self.state.allow_poll_only
+        self.state.mark_initial_reconcile(result.succeeded)
+        return result.succeeded and watcher_gate
+
+    def run_forever(
+        self,
+        scan_interval_s: float = 60.0,
+        poll_interval_s: float = 0.5,
+        startup_retry_s: float = 2.0,
+    ) -> None:
         """Run the mirror loop until the process is killed.
 
         ``scan_interval_s`` (default 60s) is how often the periodic full scan
@@ -326,13 +496,19 @@ class Mirror:
         NOT the per-DB SQLite cadence, which is each entry's ``poll_interval_ms``
         enforced inside :meth:`poll_sqlite`.
         """
-        self.start_watching()
-        log.info("startup full scan (%d entries)", len(self._handlers))
-        self.full_scan()
-        self.state.mark_startup_scan_done()
+        while not self.startup_once():
+            log.error("startup reconcile incomplete; retrying in %.1fs", startup_retry_s)
+            self._wakeup.wait(timeout=startup_retry_s)
+            self._wakeup.clear()
+        log.info("startup reconcile complete; sidecar ready")
         last_scan = time.monotonic()
         while True:
             try:
+                if self._observer is not None and not self._observer_healthy(self._observer):
+                    log.error("watchdog observer stopped after readiness; running degraded")
+                    self._cleanup_observer(self._observer)
+                    self._observer = None
+                    self.state.mark_watching(False, all_required_armed=False)
                 self._wakeup.wait(timeout=poll_interval_s)
                 self._wakeup.clear()
                 now = time.monotonic()
@@ -363,7 +539,13 @@ def main() -> int:
     max_queue = int(os.environ.get("STATE_MIRROR_MAX_QUEUE", DEFAULT_MAX_QUEUE))
     log.info("state-mirror sidecar starting (ufm_version=%s, max_queue=%d)", ufm_version, max_queue)
 
-    state = HealthState()
+    allow_poll_only = os.environ.get("STATE_MIRROR_ALLOW_POLL_ONLY", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    state = HealthState(allow_poll_only=allow_poll_only)
     HealthServer(state, port=port).start()
     try:
         classifier = Classifier.load_file(classifier_path)

--- a/ufm-state-mirror/state_mirror/mirror.py
+++ b/ufm-state-mirror/state_mirror/mirror.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sqlite3
 import threading
 import time
 from collections import OrderedDict
@@ -32,6 +33,7 @@ from contextlib import suppress
 
 from state_mirror.classifier import Classifier, Entry, Handler
 from state_mirror.handlers import MirrorResult, make_handler
+from state_mirror.handlers.base import path_exists
 from state_mirror.handlers.sqlite import SqliteHandler
 from state_mirror.health import DEFAULT_PORT, HealthServer, HealthState
 from state_mirror.redis_errors import classify_redis_error
@@ -51,6 +53,8 @@ def _reason(exc: BaseException) -> str:
     present (set at the store boundary, by the active backend's classifier),
     else fall back to a generic transport/OS classification.
     """
+    if isinstance(exc, sqlite3.Error):
+        return "local_io"
     return getattr(exc, "reason", None) or classify_redis_error(exc)
 
 
@@ -99,8 +103,16 @@ class Mirror:
     def _mark_dirty(self, entry: Entry) -> None:
         with self._lock:
             self._dirty.add(entry.path)
-            if entry.handler is Handler.SQLITE and entry.redis_key and os.path.exists(entry.path):
-                self._known_drift.discard(entry.redis_key)
+        if entry.handler is Handler.SQLITE and entry.redis_key:
+            try:
+                reappeared = path_exists(entry.path)
+            except OSError as exc:
+                log.error("cannot inspect dirty SQLite path %s: %s", entry.path, exc)
+                self.state.record_error(_reason(exc), backend_unreachable=False)
+            else:
+                if reappeared:
+                    with self._lock:
+                        self._known_drift.discard(entry.redis_key)
         self.state.inc_events()
         self._wakeup.set()
 
@@ -110,7 +122,17 @@ class Mirror:
             return
         key = handler.key_for_fs_path(fs_path)
         if isinstance(handler, SqliteHandler):
-            if os.path.exists(fs_path):
+            try:
+                reappeared = path_exists(fs_path)
+            except OSError as exc:
+                log.error("cannot inspect deleted SQLite path %s: %s", fs_path, exc)
+                with self._lock:
+                    self._dirty.add(entry.path)
+                self.state.record_error(_reason(exc), backend_unreachable=False)
+                self.state.inc_events()
+                self._wakeup.set()
+                return
+            if reappeared:
                 # The delete event raced with DB recreation. Mirror the current
                 # file, but do not open an unexpected-delete onset.
                 with self._lock:
@@ -196,7 +218,7 @@ class Mirror:
         deleted = self.flush_pending_deletes()
         aggregate = aggregate.plus(deleted)
         ops += deleted.writes
-        if aggregate.failures:
+        if aggregate.backend_failures:
             self.state.mark_backend_unreachable()
         if ops:
             self.state.add_mirror_ops(ops)
@@ -218,7 +240,15 @@ class Mirror:
         failures: list[BaseException] = []
         for key, (entry_path, fs_path) in items:
             self.state.heartbeat()
-            if os.path.exists(fs_path):
+            try:
+                reappeared = path_exists(fs_path)
+            except OSError as exc:
+                reason = _reason(exc)
+                log.exception("cannot inspect pending delete %s [%s]; retaining it", key, reason)
+                self.state.record_error(reason, backend_unreachable=False)
+                failures.append(exc)
+                continue
+            if reappeared:
                 with self._lock:
                     self._pending_deletes.pop(key, None)
                 continue
@@ -260,10 +290,11 @@ class Mirror:
         flushed = self.flush_pending_deletes()
         aggregate = aggregate.plus(flushed)
         aggregate = aggregate.plus(self._scan_unexpected_deletes())
-        if aggregate.failures:
+        if aggregate.backend_failures:
             # Successful siblings may have followed a failed operation. Preserve
-            # their write/read accounting, but let any failure win final
-            # reachability for this aggregate reconcile.
+            # their write/read accounting, but let any backend failure win final
+            # reachability for this aggregate reconcile. Local failures still
+            # make the reconcile unsuccessful without misreporting the backend.
             self.state.mark_backend_unreachable()
         elif aggregate.reads:
             # Drift enumeration is itself a backend read. This matters when all
@@ -289,6 +320,7 @@ class Mirror:
             pending = set(self._pending_deletes)
             known_at_start = set(self._known_drift)
         current: set[str] = set()
+        present_paths: set[str] = set()
         failures: list[BaseException] = []
         reads = 0
         for handler in self._handlers:
@@ -298,12 +330,15 @@ class Mirror:
                 # present; directories always enumerate their backend prefix.
                 # Count only real backend reads so startup still probes when a
                 # scan consisted entirely of local no-ops.
-                reads_backend = handler.entry.is_directory or not os.path.exists(handler.entry.path)
+                local_exists = path_exists(handler.entry.path)
+                if local_exists:
+                    present_paths.add(handler.entry.path)
+                reads_backend = handler.entry.is_directory or not local_exists
                 current.update(handler.drift_keys())
                 if (
                     isinstance(handler, SqliteHandler)
                     and handler.entry.redis_key in known_at_start
-                    and not os.path.exists(handler.entry.path)
+                    and not local_exists
                 ):
                     # Observed SQLite deletion is an operator-error onset even
                     # when no durable snapshot exists. Do not count it again
@@ -313,7 +348,9 @@ class Mirror:
             except Exception as exc:
                 reason = _reason(exc)
                 log.exception("drift check failed for %s [%s]", handler.entry.path, reason)
-                self.state.record_store_down(reason)
+                self.state.record_error(
+                    reason, backend_unreachable=MirrorResult.failure_affects_backend(exc)
+                )
                 failures.append(exc)
                 # A failed scope is unknown, not healthy. Retain its previous
                 # drift-onset state so a transient outage cannot double-count
@@ -332,7 +369,7 @@ class Mirror:
                 if (
                     isinstance(handler, SqliteHandler)
                     and handler.entry.redis_key
-                    and os.path.exists(handler.entry.path)
+                    and handler.entry.path in present_paths
                 ):
                     current.discard(handler.entry.redis_key)
             new_drift = current - self._known_drift
@@ -381,7 +418,7 @@ class Mirror:
                 )
         if sent:
             self.state.add_mirror_ops(sent)
-        if aggregate.failures:
+        if aggregate.backend_failures:
             self.state.mark_backend_unreachable()
         return sent
 
@@ -394,13 +431,16 @@ class Mirror:
             return MirrorResult(failures=(exc,))
 
     def _record_result(self, result: MirrorResult) -> None:
-        """Apply WROTE > READ_OK > LOCAL_NOOP, then let failures win."""
+        """Apply activity first, then record failures by their health domain."""
         if result.writes:
             self.state.record_write_ok()
         elif result.reads:
             self.state.record_read_ok()
         for exc in result.failures:
-            self.state.record_store_down(_reason(exc))
+            self.state.record_error(
+                _reason(exc),
+                backend_unreachable=MirrorResult.failure_affects_backend(exc),
+            )
 
     def _cleanup_observer(self, observer) -> None:
         with suppress(Exception):
@@ -459,7 +499,7 @@ class Mirror:
         if not watchers_ok:
             watchers_ok = self.start_watching()
         result = self.full_scan()
-        if result.succeeded and result.backend_ops == 0:
+        if not result.backend_failures and result.backend_ops == 0:
             try:
                 self.store.probe()
                 self.state.record_read_ok()

--- a/ufm-state-mirror/state_mirror/mirror.py
+++ b/ufm-state-mirror/state_mirror/mirror.py
@@ -36,7 +36,7 @@ from state_mirror.handlers import MirrorResult, make_handler
 from state_mirror.handlers.base import path_exists
 from state_mirror.handlers.sqlite import SqliteHandler
 from state_mirror.health import DEFAULT_PORT, HealthServer, HealthState
-from state_mirror.redis_errors import classify_redis_error
+from state_mirror.redis_errors import LOCAL_IO_REASON, classify_redis_error
 from state_mirror.watcher import MirrorEventHandler, PathResolver, build_observer
 
 log = logging.getLogger("state_mirror.mirror")
@@ -54,7 +54,7 @@ def _reason(exc: BaseException) -> str:
     else fall back to a generic transport/OS classification.
     """
     if isinstance(exc, sqlite3.Error):
-        return "local_io"
+        return LOCAL_IO_REASON
     return getattr(exc, "reason", None) or classify_redis_error(exc)
 
 

--- a/ufm-state-mirror/state_mirror/redis_errors.py
+++ b/ufm-state-mirror/state_mirror/redis_errors.py
@@ -39,6 +39,8 @@ with fakes (matching the rest of the package's lazy-import discipline).
 
 from __future__ import annotations
 
+LOCAL_IO_REASON = "local_io"
+
 # Canonical, fixed label set. Pre-seeded to 0 in metrics so every series is
 # present for dashboards/alerts before the first error occurs.
 REDIS_ERROR_REASONS: tuple[str, ...] = (
@@ -52,7 +54,7 @@ REDIS_ERROR_REASONS: tuple[str, ...] = (
     "conn",
     "timeout",
     "response",
-    "local_io",
+    LOCAL_IO_REASON,
     "other",
 )
 
@@ -82,7 +84,7 @@ def classify_redis_error(exc: BaseException) -> str:
     the fallback. Never raises -- an unknown exception classifies as ``other``.
     """
     if isinstance(exc, OSError):
-        return "local_io"
+        return LOCAL_IO_REASON
 
     msg = str(exc).upper()
     # Redis server error string codes (most specific first). Substring matching,

--- a/ufm-state-mirror/state_mirror/store.py
+++ b/ufm-state-mirror/state_mirror/store.py
@@ -70,6 +70,10 @@ class Store(ABC):
     def list_keys(self, prefix: str) -> list[str]:
         """Return every stored key (decoded) beginning with ``prefix``."""
 
+    @abstractmethod
+    def probe(self) -> None:
+        """Perform a cheap backend round-trip or raise on failure."""
+
 
 class RedisStore(Store):
     """:class:`Store` backed by Redis/Valkey: one body key + one ``:meta`` key.
@@ -104,6 +108,9 @@ class RedisStore(Store):
         for key in self._client.scan_iter(match=prefix + "*"):
             keys.append(key.decode() if isinstance(key, (bytes, bytearray)) else key)
         return keys
+
+    def probe(self) -> None:
+        self._client.ping()
 
 
 # --- ConfigMap backend (HLD 5.3.x) ---------------------------------------
@@ -264,6 +271,15 @@ class ConfigMapStore(Store):
             if key is not None and key.startswith(prefix):
                 keys.append(key)
         return keys
+
+    def probe(self) -> None:
+        """Prove API/RBAC reachability without mutating cluster state."""
+        selector = f"{MANAGED_BY_LABEL}={MANAGED_BY_VALUE}"
+        try:
+            self._api.list_cms(selector)
+        except Exception as exc:
+            reason = classify_k8s_error(exc)
+            raise wire.WireError(f"configmap probe failed: {exc}", reason=reason) from exc
 
     # --- internals -------------------------------------------------------
 

--- a/ufm-state-mirror/state_mirror/watcher.py
+++ b/ufm-state-mirror/state_mirror/watcher.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 from state_mirror.classifier import Entry
@@ -36,6 +37,20 @@ log = logging.getLogger(__name__)
 EVENT_CLOSED = "closed"
 EVENT_MOVED = "moved"
 EVENT_DELETED = "deleted"
+
+
+@dataclass(frozen=True)
+class ObserverSetup:
+    """Result of scheduling every required watch before observer startup."""
+
+    observer: object
+    required: int
+    scheduled: int
+    failures: tuple[BaseException, ...] = ()
+
+    @property
+    def complete(self) -> bool:
+        return not self.failures and self.scheduled == self.required
 
 
 class PathResolver:
@@ -130,17 +145,20 @@ class MirrorEventHandler:
             self._mark_dirty(entry)
 
 
-def build_observer(resolver: PathResolver, handler: MirrorEventHandler):
+def build_observer(resolver: PathResolver, handler: MirrorEventHandler) -> ObserverSetup:
     """Create, schedule, and return a watchdog ``Observer`` (not started).
 
-    Missing watch directories are created; a directory that cannot be watched is
-    logged and skipped (the periodic full scan still covers it).
+    Missing watch directories are created. Failures are returned to the caller,
+    which blocks readiness in strict mode or exposes the explicit unsupported
+    poll-only escape hatch.
     """
     from watchdog.observers import Observer
 
     observer = Observer()
+    watches = resolver.watch_dirs()
     scheduled = 0
-    for directory, recursive in resolver.watch_dirs():
+    failures: list[BaseException] = []
+    for directory, recursive in watches:
         try:
             if not os.path.isdir(directory):
                 log.info("creating missing watch directory %s", directory)
@@ -149,6 +167,12 @@ def build_observer(resolver: PathResolver, handler: MirrorEventHandler):
             log.info("watching %s (recursive=%s)", directory, recursive)
             scheduled += 1
         except OSError as exc:
-            log.error("cannot watch %s: %s (relying on periodic scan)", directory, exc)
+            log.error("cannot create/schedule required watch %s: %s", directory, exc)
+            failures.append(exc)
     log.info("watchdog scheduled %d watch(es)", scheduled)
-    return observer
+    return ObserverSetup(
+        observer=observer,
+        required=len(watches),
+        scheduled=scheduled,
+        failures=tuple(failures),
+    )

--- a/ufm-state-mirror/tests/conftest.py
+++ b/ufm-state-mirror/tests/conftest.py
@@ -61,6 +61,9 @@ class FakeRedis:
         pattern = match if match is not None else "*"
         return iter([k for k in list(self.store) if fnmatch.fnmatch(k, pattern)])
 
+    def ping(self):
+        return True
+
 
 @pytest.fixture
 def fake_redis():

--- a/ufm-state-mirror/tests/test_configmap_store.py
+++ b/ufm-state-mirror/tests/test_configmap_store.py
@@ -98,6 +98,10 @@ def _put(store, key, body, handler="blob", ufm_version="7.0.1"):
 
 
 class TestRoundTrip:
+    def test_probe_is_read_only(self, cm_store, cm_api):
+        cm_store.probe()
+        assert cm_api.objs == {}
+
     def test_put_then_get(self, cm_store):
         _put(cm_store, "ufm:cfg:plugins", b"payload")
         body, meta = cm_store.get("ufm:cfg:plugins")
@@ -177,6 +181,15 @@ class TestFailClosed:
 
 
 class TestErrorClassification:
+    def test_probe_403_raises_forbidden(self, cm_store, cm_api):
+        def boom(_selector):
+            raise _ApiException(403)
+
+        cm_api.list_cms = boom
+        with pytest.raises(wire.WireError) as ei:
+            cm_store.probe()
+        assert ei.value.reason == "forbidden"
+
     def test_read_404_returns_none(self, cm_store, cm_api):
         def boom(_name):
             raise _ApiException(404)

--- a/ufm-state-mirror/tests/test_handlers.py
+++ b/ufm-state-mirror/tests/test_handlers.py
@@ -15,12 +15,10 @@
 import os
 import sqlite3
 
-import pytest
-
 from state_mirror import wire
 from state_mirror.classifier import Entry
 from state_mirror.handlers import base, make_handler
-from state_mirror.handlers.base import BaseHandler
+from state_mirror.handlers.base import BaseHandler, MirrorOutcome
 from state_mirror.handlers.blob import BlobHandler
 from state_mirror.handlers.directory import DirectoryHandler
 from state_mirror.handlers.sqlite import SqliteHandler
@@ -42,12 +40,12 @@ class TestBlobHandler:
         handler = _handler(entry, fake_redis)
         assert isinstance(handler, BlobHandler)
 
-        assert handler.mirror() is True
+        assert handler.mirror().outcome is MirrorOutcome.WROTE
         # unchanged -> idempotent no-op
-        assert handler.mirror() is False
+        assert handler.mirror().outcome is MirrorOutcome.READ_OK
         # change -> ships again
         src.write_bytes(b'{"v": 2}')
-        assert handler.mirror() is True
+        assert handler.mirror().outcome is MirrorOutcome.WROTE
 
         # restore into a fresh location
         dest = tmp_path / "restored" / "a.json"
@@ -109,7 +107,7 @@ class TestDirectoryHandler:
         )
         handler = _handler(entry, fake_redis)
         assert isinstance(handler, DirectoryHandler)
-        assert handler.mirror() is True
+        assert handler.mirror().outcome is MirrorOutcome.WROTE
         assert fake_redis.get("ufm:cfg:plugins:a.conf") == b"AAA"
         assert fake_redis.get("ufm:cfg:plugins:sub/b.conf") == b"BBB"
 
@@ -157,8 +155,10 @@ class TestDirectoryHandler:
             raise wire.WireError("backend down", reason="conn")
 
         monkeypatch.setattr(handler.store, "get_meta", boom)
-        with pytest.raises(wire.WireError):
-            handler.mirror()
+        result = handler.mirror()
+        assert result.outcome is MirrorOutcome.LOCAL_NOOP
+        assert len(result.failures) == 1
+        assert isinstance(result.failures[0], wire.WireError)
 
     def test_mirror_skips_unreadable_child(self, fake_redis, tmp_path, monkeypatch):
         # A local read error for one child is skipped (not fatal) so the rest of
@@ -171,15 +171,17 @@ class TestDirectoryHandler:
             {"path": str(root), "handler": "directory", "redis_key_prefix": "ufm:cfg:plugins:"}
         )
         handler = _handler(entry, fake_redis)
-        real_read = base.BaseHandler._read_file
+        real_read = handler._read_file
 
         def selective(path):
             if path.endswith("a.conf"):
                 raise OSError("unreadable")
             return real_read(path)
 
-        monkeypatch.setattr(base.BaseHandler, "_read_file", staticmethod(selective))
-        assert handler.mirror() is True  # b.conf still shipped despite a.conf failing
+        monkeypatch.setattr(handler, "_read_file", selective)
+        result = handler.mirror()
+        assert result.outcome is MirrorOutcome.WROTE
+        assert len(result.failures) == 1  # b.conf still shipped despite a.conf failing
         assert fake_redis.get("ufm:cfg:plugins:a.conf") is None
         assert fake_redis.get("ufm:cfg:plugins:b.conf") == b"BBB"
 
@@ -220,7 +222,7 @@ class TestSqliteHandler:
         )
         handler = _handler(entry, fake_redis)
         assert isinstance(handler, SqliteHandler)
-        assert handler.mirror() is True
+        assert handler.mirror().outcome is MirrorOutcome.WROTE
 
         # restore to a new path and confirm it opens with the same rows
         dest = str(tmp_path / "restored" / "gv.db")

--- a/ufm-state-mirror/tests/test_handlers.py
+++ b/ufm-state-mirror/tests/test_handlers.py
@@ -15,6 +15,8 @@
 import os
 import sqlite3
 
+import pytest
+
 from state_mirror import wire
 from state_mirror.classifier import Entry
 from state_mirror.handlers import base, make_handler
@@ -90,6 +92,20 @@ class TestBlobHandler:
         assert fake_redis.get("ufm:state:a") is None
         assert fake_redis.get("ufm:state:a:meta") is None
 
+    def test_mirror_propagates_local_inspection_error(self, fake_redis, tmp_path, monkeypatch):
+        src = tmp_path / "a.json"
+        src.write_bytes(b"content")
+        entry = Entry.from_dict({"path": str(src), "handler": "blob", "redis_key": "ufm:state:a"})
+        handler = _handler(entry, fake_redis)
+
+        def deny_stat(_path):
+            raise PermissionError("cannot inspect local file")
+
+        with monkeypatch.context() as patch:
+            patch.setattr(base.os, "stat", deny_stat)
+            with pytest.raises(PermissionError):
+                handler.mirror()
+
 
 class TestDirectoryHandler:
     def test_directory_roundtrip(self, fake_redis, tmp_path):
@@ -140,6 +156,22 @@ class TestDirectoryHandler:
         handler.on_delete_child("a.conf")
         assert fake_redis.get("ufm:cfg:plugins:a.conf") is None
 
+    def test_present_non_directory_root_fails_reconcile(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        root.write_bytes(b"not a directory")
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+                "recursive": True,
+            }
+        )
+        result = _handler(entry, fake_redis).mirror()
+        assert result.succeeded is False
+        assert isinstance(result.failures[0], NotADirectoryError)
+        assert result.backend_failures == ()
+
     def test_mirror_propagates_backend_error(self, fake_redis, tmp_path, monkeypatch):
         # A backend failure on a child must NOT be swallowed: it propagates so
         # the caller records the outage instead of seeing a healthy run (FIX-2).
@@ -184,6 +216,63 @@ class TestDirectoryHandler:
         assert len(result.failures) == 1  # b.conf still shipped despite a.conf failing
         assert fake_redis.get("ufm:cfg:plugins:a.conf") is None
         assert fake_redis.get("ufm:cfg:plugins:b.conf") == b"BBB"
+
+    def test_recursive_walk_error_fails_reconcile(self, fake_redis, tmp_path, monkeypatch):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+                "recursive": True,
+            }
+        )
+        handler = _handler(entry, fake_redis)
+
+        def fail_walk(_root, *, onerror):
+            onerror(PermissionError("cannot traverse local subtree"))
+            return iter(())
+
+        with monkeypatch.context() as patch:
+            patch.setattr(os, "walk", fail_walk)
+            result = handler.mirror()
+        assert result.succeeded is False
+        assert isinstance(result.failures[0], PermissionError)
+        assert result.backend_failures == ()
+
+    def test_traversal_failure_preserves_earlier_backend_failure(
+        self, fake_redis, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        child = root / "a.conf"
+        child.write_bytes(b"AAA")
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+                "recursive": True,
+            }
+        )
+        handler = _handler(entry, fake_redis)
+        backend_failure = wire.WireError("backend down", reason="conn")
+
+        def partial_walk():
+            yield "a.conf", str(child)
+            raise PermissionError("cannot traverse later subtree")
+
+        def backend_down(*_args):
+            raise backend_failure
+
+        monkeypatch.setattr(handler, "_iter_local_files", partial_walk)
+        monkeypatch.setattr(handler, "_push_if_changed", backend_down)
+        result = handler.mirror()
+        assert len(result.failures) == 2
+        assert result.failures[0] is backend_failure
+        assert isinstance(result.failures[1], PermissionError)
+        assert result.backend_failures == (backend_failure,)
 
 
 class TestSqliteHandler:

--- a/ufm-state-mirror/tests/test_health.py
+++ b/ufm-state-mirror/tests/test_health.py
@@ -33,7 +33,27 @@ class TestReadiness:
         assert s.is_ready() is False
         s.mark_watching(watchdog_active=True)
         assert s.is_ready() is False
-        s.mark_startup_scan_done()
+        s.mark_initial_reconcile(True)
+        assert s.is_ready() is True
+
+    def test_strict_mode_requires_watchers(self):
+        s = HealthState()
+        s.mark_initial_reconcile(True)
+        s.mark_watching(False, all_required_armed=False)
+        assert s.is_ready() is False
+
+    def test_explicit_poll_only_mode_can_be_ready(self):
+        s = HealthState(allow_poll_only=True)
+        s.mark_watching(False, all_required_armed=False)
+        s.mark_initial_reconcile(True)
+        assert s.is_ready() is True
+
+    def test_readiness_stays_latched_after_runtime_failure(self):
+        s = HealthState()
+        s.mark_watching(True)
+        s.mark_initial_reconcile(True)
+        s.mark_initial_reconcile(False)
+        s.mark_watching(False, all_required_armed=False)
         assert s.is_ready() is True
 
     def test_ready_route(self):
@@ -42,7 +62,7 @@ class TestReadiness:
         assert status == 503
         assert body == b"not ready\n"
         s.mark_watching(watchdog_active=True)
-        s.mark_startup_scan_done()
+        s.mark_initial_reconcile(True)
         status, _ct, body = handle_request("/ready", s)
         assert status == 200
         assert body == b"ready\n"
@@ -87,8 +107,8 @@ class TestMetrics:
     def test_metrics_reflect_state(self):
         s = HealthState()
         s.mark_watching(watchdog_active=True)
-        s.mark_startup_scan_done()
-        s.record_store_ok()
+        s.mark_initial_reconcile(True)
+        s.record_write_ok()
         s.add_mirror_ops(3)
         s.inc_full_scans()
         s.inc_events()
@@ -96,6 +116,7 @@ class TestMetrics:
         assert "state_mirror_ready 1" in text
         assert "state_mirror_backend_reachable 1" in text
         assert "state_mirror_watchdog_active 1" in text
+        assert "state_mirror_poll_only_enabled 0" in text
         assert "state_mirror_mirror_ops_total 3" in text
         assert "state_mirror_full_scans_total 1" in text
         assert "state_mirror_events_total 1" in text
@@ -129,6 +150,19 @@ class TestMetrics:
         s.record_store_down("not-a-real-reason")
         text = render_metrics(s)
         assert 'state_mirror_backend_errors_total{reason="other"} 1' in text
+
+    def test_read_ok_does_not_advance_write_timestamp(self):
+        s = HealthState()
+        s.record_store_down("conn")
+        s.record_read_ok()
+        assert s.backend_reachable is True
+        assert s.last_store_write == 0.0
+
+    def test_write_ok_advances_timestamp(self):
+        s = HealthState()
+        s.record_write_ok()
+        assert s.backend_reachable is True
+        assert s.last_store_write > 0.0
 
     def test_dropped_events_counter(self):
         s = HealthState()
@@ -165,7 +199,7 @@ class TestLiveServer:
             assert status == 503
             assert body == b"not ready\n"
             s.mark_watching(watchdog_active=True)
-            s.mark_startup_scan_done()
+            s.mark_initial_reconcile(True)
             status, body = _get(base + "/ready")
             assert status == 200
             assert body == b"ready\n"

--- a/ufm-state-mirror/tests/test_health.py
+++ b/ufm-state-mirror/tests/test_health.py
@@ -145,6 +145,13 @@ class TestMetrics:
         assert 'state_mirror_backend_errors_total{reason="forbidden"} 1' in text
         assert s.backend_reachable is False
 
+    def test_local_error_is_counted_without_marking_backend_unreachable(self):
+        s = HealthState()
+        s.record_read_ok()
+        s.record_error("local_io", backend_unreachable=False)
+        assert s.backend_errors["local_io"] == 1
+        assert s.backend_reachable is True
+
     def test_unknown_reason_buckets_to_other(self):
         s = HealthState()
         s.record_store_down("not-a-real-reason")

--- a/ufm-state-mirror/tests/test_mirror.py
+++ b/ufm-state-mirror/tests/test_mirror.py
@@ -243,6 +243,27 @@ class TestDrainFailureKeepsPending:
         m.full_scan()
         assert client.get("ufm:state:o") is None
 
+    def test_local_delete_inspection_error_keeps_backend_and_pending(
+        self, fake_redis, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "o.conf"
+        path.write_bytes(b"X")
+        state = HealthState()
+        m = _mirror(_blob_classifier(path), fake_redis, state=state)
+        m.full_scan()
+        path.unlink()
+        m._mark_delete(m._handlers[0].entry, str(path))
+
+        def deny_inspection(_path):
+            raise PermissionError("cannot determine local presence")
+
+        monkeypatch.setattr(mirror_mod, "path_exists", deny_inspection)
+        assert m.drain_once(now=0.0, rate_limited=False) == 0
+        assert fake_redis.get("ufm:state:o") == b"X"
+        assert "ufm:state:o" in m._pending_deletes
+        assert state.backend_reachable is True
+        assert state.backend_errors["local_io"] == 1
+
 
 class _AliveObserver:
     def is_alive(self):
@@ -402,6 +423,18 @@ class TestReadinessAndHealth:
         assert state.backend_reachable is False
         assert state.backend_errors["conn"] == 1
 
+    def test_partial_local_failure_does_not_mark_backend_unreachable(self, fake_redis, tmp_path):
+        state = HealthState()
+        m = _mirror(_blob_classifier(tmp_path / "state"), fake_redis, state=state)
+        failure = PermissionError("unreadable local child")
+        m._handlers[0].mirror = lambda: MirrorResult(writes=1, failures=(failure,))
+        result = m.full_scan()
+        assert result.succeeded is False
+        assert result.backend_failures == ()
+        assert state.last_store_write > 0
+        assert state.backend_reachable is True
+        assert state.backend_errors["local_io"] == 1
+
     def test_runtime_batch_failure_wins_over_later_success(self, fake_redis, tmp_path):
         first = tmp_path / "first"
         second = tmp_path / "second"
@@ -425,6 +458,43 @@ class TestReadinessAndHealth:
         assert m.drain_once(now=0.0, rate_limited=False) == 1
         assert state.backend_reachable is False
 
+    def test_runtime_local_failure_does_not_override_backend_success(self, fake_redis, tmp_path):
+        path = tmp_path / "state"
+        path.write_bytes(b"state")
+        state = HealthState()
+        m = _mirror(_blob_classifier(path), fake_redis, state=state)
+        failure = PermissionError("unreadable local file")
+        m._handlers[0].mirror = lambda: MirrorResult(failures=(failure,))
+        state.record_read_ok()
+        m._mark_dirty(m._handlers[0].entry)
+        m.drain_once(now=0.0, rate_limited=False)
+        assert state.backend_reachable is True
+        assert state.backend_errors["local_io"] == 1
+
+    def test_sqlite_poll_local_failure_does_not_mark_backend_unreachable(
+        self, fake_redis, tmp_path
+    ):
+        path = tmp_path / "gv.db"
+        classifier = Classifier.from_dict(
+            {
+                "entries": [
+                    {
+                        "path": str(path),
+                        "handler": "sqlite",
+                        "redis_key": "ufm:sqlite:gv.db",
+                    }
+                ]
+            }
+        )
+        state = HealthState()
+        m = _mirror(classifier, fake_redis, state=state)
+        failure = sqlite3.DatabaseError("local database is malformed")
+        m._handlers[0].mirror = lambda: MirrorResult(failures=(failure,))
+        state.record_read_ok()
+        assert m.poll_sqlite(now=0.0) == 0
+        assert state.backend_reachable is True
+        assert state.backend_errors["local_io"] == 1
+
     def test_zero_backend_op_startup_uses_probe(self, tmp_path):
         client = FlakyRedis()
         state = HealthState(allow_poll_only=True)
@@ -437,12 +507,27 @@ class TestReadinessAndHealth:
         assert client.ping_calls == 1
         assert state.backend_reachable is True
 
-    def test_failed_zero_op_startup_does_not_probe(self, tmp_path):
+    def test_local_failure_zero_op_startup_probes_but_remains_not_ready(self, tmp_path):
         client = FlakyRedis()
         state = HealthState(allow_poll_only=True)
         m = _mirror(_blob_classifier(tmp_path / "missing"), client, state=state)
         m.start_watching = lambda: False
-        m.full_scan = lambda: MirrorResult(failures=(RuntimeError("scan failed"),))
+        failure = PermissionError("unreadable local file")
+        m._handlers[0].mirror = lambda: MirrorResult(failures=(failure,))
+        m._scan_unexpected_deletes = lambda: MirrorResult()
+        assert m.startup_once() is False
+        assert client.ping_calls == 1
+        assert state.backend_reachable is True
+        assert state.backend_errors["local_io"] == 1
+        assert state.initial_reconcile_ok is False
+
+    def test_backend_failure_zero_op_startup_does_not_probe(self, tmp_path):
+        client = FlakyRedis()
+        state = HealthState(allow_poll_only=True)
+        m = _mirror(_blob_classifier(tmp_path / "missing"), client, state=state)
+        m.start_watching = lambda: False
+        failure = wire.WireError("backend down", reason="conn")
+        m.full_scan = lambda: MirrorResult(failures=(failure,))
         assert m.startup_once() is False
         assert client.ping_calls == 0
         assert state.backend_reachable is False

--- a/ufm-state-mirror/tests/test_mirror.py
+++ b/ufm-state-mirror/tests/test_mirror.py
@@ -13,10 +13,16 @@
 """Unit tests for the mirror loop's bounded queues and delete reconcile (D2)."""
 
 import fnmatch
+import sqlite3
 
+from state_mirror import mirror as mirror_mod
+from state_mirror import wire
 from state_mirror.classifier import Classifier
+from state_mirror.handlers.base import MirrorResult
+from state_mirror.health import HealthState
 from state_mirror.mirror import Mirror
 from state_mirror.store import RedisStore
+from state_mirror.watcher import ObserverSetup
 
 UFM_VERSION = "7.0.1"
 WRITTEN_BY = "state-mirror:test"
@@ -77,6 +83,7 @@ class FlakyRedis:
     def __init__(self):
         self.store = {}
         self.fail_delete = False
+        self.ping_calls = 0
 
     def get(self, key):
         return self.store.get(key)
@@ -96,6 +103,10 @@ class FlakyRedis:
     def scan_iter(self, match=None, count=None):
         pattern = match if match is not None else "*"
         return iter([k for k in list(self.store) if fnmatch.fnmatch(k, pattern)])
+
+    def ping(self):
+        self.ping_calls += 1
+        return True
 
 
 class TestQueueBounds:
@@ -231,3 +242,307 @@ class TestDrainFailureKeepsPending:
         client.fail_delete = False
         m.full_scan()
         assert client.get("ufm:state:o") is None
+
+
+class _AliveObserver:
+    def is_alive(self):
+        return True
+
+
+class _NeverStartedObserver:
+    def start(self):
+        raise AssertionError("incomplete setup must not start observer")
+
+
+class _DiesDuringScanObserver:
+    def __init__(self):
+        self._checks = 0
+
+    def is_alive(self):
+        self._checks += 1
+        return self._checks == 1
+
+    def stop(self):
+        pass
+
+    def join(self, timeout=None):
+        pass
+
+
+class _DeadEmitter:
+    def is_alive(self):
+        return False
+
+
+class _ObserverWithDeadEmitter(_AliveObserver):
+    emitters = (_DeadEmitter(),)
+
+    def __init__(self):
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+    def join(self, timeout=None):
+        pass
+
+
+class TestReadinessAndHealth:
+    def test_partial_watcher_setup_blocks_strict_readiness(self, fake_redis, tmp_path, monkeypatch):
+        state = HealthState()
+        m = _mirror(_blob_classifier(tmp_path / "missing"), fake_redis, state=state)
+        setup = ObserverSetup(
+            observer=_NeverStartedObserver(),
+            required=2,
+            scheduled=1,
+            failures=(OSError("inotify exhausted"),),
+        )
+        monkeypatch.setattr(mirror_mod, "build_observer", lambda *_args: setup)
+        assert m.startup_once() is False
+        assert state.is_ready() is False
+        assert state.watchdog_active is False
+
+    def test_startup_failure_does_not_latch_then_recovery_does(self, fake_redis, tmp_path):
+        state = HealthState()
+        m = _mirror(_blob_classifier(tmp_path / "missing"), fake_redis, state=state)
+        m._observer = _AliveObserver()
+        original = m.full_scan
+        m.full_scan = lambda: MirrorResult(failures=(RuntimeError("backend down"),))
+        assert m.startup_once() is False
+        assert state.is_ready() is False
+        m.full_scan = original
+        assert m.startup_once() is True
+        assert state.is_ready() is True
+
+    def test_recovered_watcher_cannot_latch_before_current_scan(self, fake_redis, tmp_path):
+        state = HealthState()
+        m = _mirror(_blob_classifier(tmp_path / "missing"), fake_redis, state=state)
+        m.start_watching = lambda: False
+        m.full_scan = lambda: MirrorResult(reads=1)
+        assert m.startup_once() is False
+        assert state.initial_reconcile_ok is True
+
+        def recover_watcher():
+            m._observer = _AliveObserver()
+            state.mark_watching(True, all_required_armed=True)
+            return True
+
+        m.start_watching = recover_watcher
+        m.full_scan = lambda: MirrorResult(failures=(RuntimeError("scan failed"),))
+        assert m.startup_once() is False
+        assert state.is_ready() is False
+
+    def test_watcher_dying_during_scan_blocks_strict_readiness(self, fake_redis, tmp_path):
+        state = HealthState()
+        m = _mirror(_blob_classifier(tmp_path / "missing"), fake_redis, state=state)
+        m._observer = _DiesDuringScanObserver()
+        assert m.startup_once() is False
+        assert state.is_ready() is False
+        assert state.watchdog_active is False
+
+    def test_dead_required_emitter_blocks_strict_readiness(self, fake_redis, tmp_path):
+        state = HealthState()
+        m = _mirror(_blob_classifier(tmp_path / "missing"), fake_redis, state=state)
+        observer = _ObserverWithDeadEmitter()
+        m._observer = observer
+        m.start_watching = lambda: False
+        assert m.startup_once() is False
+        assert state.is_ready() is False
+        assert observer.stopped is True
+
+    def test_local_noop_does_not_clear_backend_down(self, fake_redis, tmp_path):
+        state = HealthState()
+        m = _mirror(_blob_classifier(tmp_path / "missing"), fake_redis, state=state)
+        entry = m._handlers[0].entry
+        state.record_store_down("conn")
+        m._mark_dirty(entry)
+        m.drain_once(now=0.0, rate_limited=False)
+        assert state.backend_reachable is False
+
+    def test_successful_read_does_not_advance_write_timestamp(self, fake_redis, tmp_path):
+        path = tmp_path / "state"
+        path.write_bytes(b"v1")
+        state = HealthState()
+        m = _mirror(_blob_classifier(path), fake_redis, state=state)
+        m.full_scan()
+        written_at = state.last_store_write
+        state.record_store_down("conn")
+        m.full_scan()
+        assert state.backend_reachable is True
+        assert state.last_store_write == written_at
+
+    def test_successful_drift_read_clears_backend_down(self, fake_redis, tmp_path):
+        path = tmp_path / "missing"
+        body = b"durable"
+        wire.write_pair(
+            fake_redis,
+            "ufm:state:o",
+            body,
+            wire.build_meta(body, "blob", UFM_VERSION, WRITTEN_BY),
+        )
+        state = HealthState()
+        m = _mirror(_blob_classifier(path), fake_redis, state=state)
+        state.record_store_down("conn")
+        result = m.full_scan()
+        assert result.reads == 1
+        assert state.backend_reachable is True
+        assert state.last_store_write == 0.0
+
+    def test_partial_failure_advances_write_but_failure_wins_reachability(
+        self, fake_redis, tmp_path
+    ):
+        state = HealthState()
+        m = _mirror(_blob_classifier(tmp_path / "state"), fake_redis, state=state)
+        failure = wire.WireError("one child failed", reason="conn")
+        m._handlers[0].mirror = lambda: MirrorResult(writes=2, failures=(failure,))
+        result = m.full_scan()
+        assert result.writes == 2
+        assert result.failures == (failure,)
+        assert state.last_store_write > 0
+        assert state.backend_reachable is False
+        assert state.backend_errors["conn"] == 1
+
+    def test_runtime_batch_failure_wins_over_later_success(self, fake_redis, tmp_path):
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.write_bytes(b"first")
+        second.write_bytes(b"second")
+        classifier = Classifier.from_dict(
+            {
+                "entries": [
+                    {"path": str(first), "handler": "blob", "redis_key": "ufm:first"},
+                    {"path": str(second), "handler": "blob", "redis_key": "ufm:second"},
+                ]
+            }
+        )
+        state = HealthState()
+        m = _mirror(classifier, fake_redis, state=state)
+        failure = wire.WireError("first failed", reason="conn")
+        results = iter((MirrorResult(failures=(failure,)), MirrorResult(writes=1)))
+        m._mirror_handler = lambda _handler: next(results)
+        m._mark_dirty(m._handlers[0].entry)
+        m._mark_dirty(m._handlers[1].entry)
+        assert m.drain_once(now=0.0, rate_limited=False) == 1
+        assert state.backend_reachable is False
+
+    def test_zero_backend_op_startup_uses_probe(self, tmp_path):
+        client = FlakyRedis()
+        state = HealthState(allow_poll_only=True)
+        m = _mirror(_blob_classifier(tmp_path / "missing"), client, state=state)
+        m.start_watching = lambda: False
+        # Avoid drift's get_meta so this is a true all-local-noop scan from the
+        # startup aggregator's perspective; startup_once must still probe.
+        m._scan_unexpected_deletes = lambda: MirrorResult()
+        assert m.startup_once() is True
+        assert client.ping_calls == 1
+        assert state.backend_reachable is True
+
+    def test_failed_zero_op_startup_does_not_probe(self, tmp_path):
+        client = FlakyRedis()
+        state = HealthState(allow_poll_only=True)
+        m = _mirror(_blob_classifier(tmp_path / "missing"), client, state=state)
+        m.start_watching = lambda: False
+        m.full_scan = lambda: MirrorResult(failures=(RuntimeError("scan failed"),))
+        assert m.startup_once() is False
+        assert client.ping_calls == 0
+        assert state.backend_reachable is False
+
+
+class TestSqliteDeletePolicy:
+    def test_reappearance_during_drift_scan_does_not_leave_stale_onset(self, fake_redis, tmp_path):
+        path = tmp_path / "gv.db"
+        classifier = Classifier.from_dict(
+            {
+                "entries": [
+                    {
+                        "path": str(path),
+                        "handler": "sqlite",
+                        "redis_key": "ufm:sqlite:gv.db",
+                    }
+                ]
+            }
+        )
+        m = _mirror(classifier, fake_redis)
+
+        def reappear_while_scanning():
+            path.write_bytes(b"reappeared")
+            return ["ufm:sqlite:gv.db"]
+
+        m._handlers[0].drift_keys = reappear_while_scanning
+        m._scan_unexpected_deletes()
+        assert "ufm:sqlite:gv.db" not in m._known_drift
+        assert m.state.unexpected_deletes_total == 0
+
+    def test_stale_delete_after_reappearance_is_treated_as_dirty(self, fake_redis, tmp_path):
+        path = tmp_path / "gv.db"
+        path.write_bytes(b"recreated")
+        classifier = Classifier.from_dict(
+            {
+                "entries": [
+                    {
+                        "path": str(path),
+                        "handler": "sqlite",
+                        "redis_key": "ufm:sqlite:gv.db",
+                    }
+                ]
+            }
+        )
+        m = _mirror(classifier, fake_redis)
+        entry = m._handlers[0].entry
+        m._mark_delete(entry, str(path))
+        assert m.state.unexpected_deletes_total == 0
+        assert entry.path in m._dirty
+
+    def test_sqlite_delete_keeps_backend_and_counts_once_per_onset(self, fake_redis, tmp_path):
+        path = tmp_path / "gv.db"
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+        classifier = Classifier.from_dict(
+            {
+                "entries": [
+                    {
+                        "path": str(path),
+                        "handler": "sqlite",
+                        "redis_key": "ufm:sqlite:gv.db",
+                    }
+                ]
+            }
+        )
+        m = _mirror(classifier, fake_redis)
+        m.full_scan()
+        body = fake_redis.get("ufm:sqlite:gv.db")
+        path.unlink()
+        entry = m._handlers[0].entry
+        m._mark_delete(entry, str(path))
+        m._mark_delete(entry, str(path))
+        assert fake_redis.get("ufm:sqlite:gv.db") == body
+        assert m.state.unexpected_deletes_total == 1
+        assert not m._pending_deletes
+
+        path.write_bytes(body)
+        m._mark_dirty(entry)
+        path.unlink()
+        m._mark_delete(entry, str(path))
+        assert m.state.unexpected_deletes_total == 2
+
+    def test_missing_backend_does_not_reset_sqlite_delete_onset(self, fake_redis, tmp_path):
+        path = tmp_path / "gv.db"
+        classifier = Classifier.from_dict(
+            {
+                "entries": [
+                    {
+                        "path": str(path),
+                        "handler": "sqlite",
+                        "redis_key": "ufm:sqlite:gv.db",
+                    }
+                ]
+            }
+        )
+        m = _mirror(classifier, fake_redis)
+        entry = m._handlers[0].entry
+        m._mark_delete(entry, str(path))
+        m.full_scan()
+        m._mark_delete(entry, str(path))
+        assert m.state.unexpected_deletes_total == 1

--- a/ufm-state-mirror/tests/test_mirror.py
+++ b/ufm-state-mirror/tests/test_mirror.py
@@ -551,9 +551,9 @@ class TestSqliteDeletePolicy:
 
         def reappear_while_scanning():
             path.write_bytes(b"reappeared")
-            return ["ufm:sqlite:gv.db"]
+            return ["ufm:sqlite:gv.db"], 1
 
-        m._handlers[0].drift_keys = reappear_while_scanning
+        m._handlers[0].drift_scan = reappear_while_scanning
         m._scan_unexpected_deletes()
         assert "ufm:sqlite:gv.db" not in m._known_drift
         assert m.state.unexpected_deletes_total == 0

--- a/ufm-state-mirror/tests/test_sqlite.py
+++ b/ufm-state-mirror/tests/test_sqlite.py
@@ -13,6 +13,7 @@
 """Unit tests for the Phase 5 SQLite handler: snapshot-only online-backup
 mirroring, change detection, and integrity-checked, fail-closed restore."""
 
+import os
 import sqlite3
 
 import pytest
@@ -108,6 +109,24 @@ class TestSnapshot:
         conn.commit()
         conn.close()
         assert h.signature() != sig1
+
+    def test_signature_propagates_local_wal_inspection_error(
+        self, fake_redis, tmp_path, monkeypatch
+    ):
+        db = tmp_path / "gv.db"
+        _make_db(str(db), ["a"])
+        h = _handler(db, fake_redis)
+        real_stat = os.stat
+
+        def deny_wal_stat(path):
+            if str(path).endswith("-wal"):
+                raise PermissionError("cannot inspect WAL")
+            return real_stat(path)
+
+        with monkeypatch.context() as patch:
+            patch.setattr("state_mirror.handlers.sqlite.os.stat", deny_wal_stat)
+            with pytest.raises(PermissionError):
+                h.signature()
 
     def test_mirror_reships_after_change(self, fake_redis, tmp_path):
         db = tmp_path / "gv.db"

--- a/ufm-state-mirror/tests/test_sqlite.py
+++ b/ufm-state-mirror/tests/test_sqlite.py
@@ -19,6 +19,7 @@ import pytest
 
 from state_mirror import wire
 from state_mirror.classifier import Entry
+from state_mirror.handlers.base import MirrorOutcome
 from state_mirror.handlers.sqlite import SqliteHandler
 from state_mirror.store import RedisStore
 
@@ -73,17 +74,17 @@ class TestIntegrity:
 class TestSnapshot:
     def test_mirror_skips_missing_and_empty(self, fake_redis, tmp_path):
         h = _handler(tmp_path / "absent.db", fake_redis)
-        assert h.mirror() is False
+        assert h.mirror().outcome is MirrorOutcome.LOCAL_NOOP
         empty = tmp_path / "empty.db"
         empty.write_bytes(b"")
-        assert _handler(empty, fake_redis).mirror() is False
+        assert _handler(empty, fake_redis).mirror().outcome is MirrorOutcome.LOCAL_NOOP
 
     def test_snapshot_roundtrip(self, fake_redis, tmp_path):
         db = tmp_path / "gv.db"
         _make_db(str(db), ["a", "b", "c"])
         h = _handler(db, fake_redis)
-        assert h.mirror() is True
-        assert h.mirror() is False  # unchanged -> no-op
+        assert h.mirror().outcome is MirrorOutcome.WROTE
+        assert h.mirror().outcome is MirrorOutcome.LOCAL_NOOP
         assert fake_redis.get("ufm:sqlite:gv.db") is not None
         # Snapshot-only: no WAL/epoch keys are ever written.
         assert fake_redis.get("ufm:sqlite:gv.db:epoch") is None
@@ -112,18 +113,17 @@ class TestSnapshot:
         db = tmp_path / "gv.db"
         _make_db(str(db), ["a"])
         h = _handler(db, fake_redis)
-        assert h.mirror() is True
+        assert h.mirror().outcome is MirrorOutcome.WROTE
         conn = sqlite3.connect(str(db))
         conn.execute("INSERT INTO t (v) VALUES ('b')")
         conn.commit()
         conn.close()
-        assert h.mirror() is True  # content changed -> re-shipped
+        assert h.mirror().outcome is MirrorOutcome.WROTE
 
         dest = tmp_path / "restored" / "gv.db"
         rh = _handler(dest, fake_redis)
         assert rh.restore() is True
         assert _row_count(str(dest)) == 2
-
 
 class TestRestoreFailClosed:
     def test_restore_raises_on_corrupt_base(self, fake_redis, tmp_path):

--- a/ufm-state-mirror/tests/test_sqlite.py
+++ b/ufm-state-mirror/tests/test_sqlite.py
@@ -125,6 +125,7 @@ class TestSnapshot:
         assert rh.restore() is True
         assert _row_count(str(dest)) == 2
 
+
 class TestRestoreFailClosed:
     def test_restore_raises_on_corrupt_base(self, fake_redis, tmp_path):
         # Store a base whose bytes are not a valid DB; restore must fail closed.


### PR DESCRIPTION
## What

Make StateMirror startup fail closed and make backend-health reporting reflect real mirror activity.

- Gate readiness on a successful initial reconcile and healthy required watchdog emitters.
- Keep readiness latched after startup while reporting runtime degradation.
- Add an explicit unsupported poll-only escape hatch.
- Distinguish writes, backend reads, and local no-ops.
- Preserve partial failures: backend failures win aggregate reachability, while
  local failures fail reconciliation without a false backend-outage signal.
- Treat ambiguous local inspection as a fail-closed reconcile error, including
  directory traversal, SQLite fingerprints, and pending-delete checks.
- Retain SQLite backend snapshots after local deletion and count once per onset.
- Correct dropped-delete metric documentation.

## Why ?

Redmine [#5134987](https://redmine.mellanox.com/issues/5134987), under story [#5079041](https://redmine.mellanox.com/issues/5079041).

The sidecar could report ready before mirroring and watchers were usable, and no-op or partial-result accounting could mask outages or incorrectly advance write-lag metrics.

## How ?

Handlers return an explicit `MirrorResult` containing write/read counts and failures. Drift scans report their actual backend activity instead of inferring it from racy path state. Startup retries until the initial reconcile, backend proof, and strict watcher-health gate all pass. Watcher health covers the dispatcher and every scheduled emitter.

This is **1/3** in a stacked series:

1. This PR — startup correctness and health accounting.
2. [PR #382](https://github.com/Mellanox/ufm_sdk_3.0/pull/382) — directory and classifier path safety.
3. [PR #383](https://github.com/Mellanox/ufm_sdk_3.0/pull/383) — SQLite replacement detection and logging parity.

## Testing ?

- Python 3.12: `ruff check .` — passed.
- Python 3.12: `ruff format --check .` — passed.
- Python 3.12: `python -m pytest -q` — **217 passed**.
- `git diff --check` — passed.
- NVIDIA copyright validation — passed.
- Fresh-context review — no actionable correctness regressions.
- GitHub Actions Docker build — passed.
