### PR TITLE
issue:5134987 [BugFix] [2/3] Harden state mirror path safety

### DIFF
--- a/ufm-state-mirror/state_mirror/classifier.py
+++ b/ufm-state-mirror/state_mirror/classifier.py
@@ -24,6 +24,7 @@ descriptive fields without breaking the load.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
@@ -167,7 +168,7 @@ class Classifier:
         return classifier
 
     def _check_uniqueness(self) -> None:
-        """Reject duplicate paths and duplicate/overlapping keyspaces.
+        """Reject overlapping filesystem ownership and backend keyspaces.
 
         Reports *every* problem in one error rather than failing on the first,
         so a misconfigured classifier surfaces all its issues at once -- but
@@ -175,15 +176,25 @@ class Classifier:
         duplicates this also rejects *nested* keyspaces: a non-directory
         ``redis_key`` that falls under a directory ``redis_key_prefix`` (or one
         prefix nested under another) would collide on restore, where the
-        directory handler enumerates every key under its prefix.
+        directory handler enumerates every key under its prefix. A file nested
+        below a recursive directory is likewise rejected because two handlers
+        would otherwise own the same filesystem path.
         """
         errors: list[str] = []
         paths: set[str] = set()
         seen: list[tuple[str, bool]] = []  # (key_or_prefix, is_prefix), in order
+        entries_seen: list[Entry] = []
         for e in self.entries:
-            if e.path in paths:
+            normalized_path = os.path.realpath(e.path)
+            if normalized_path in paths:
                 errors.append(f"duplicate path: {e.path}")
-            paths.add(e.path)
+            paths.add(normalized_path)
+            for other in entries_seen:
+                if _filesystem_path_overlap(e, other):
+                    errors.append(
+                        f"filesystem paths {e.path!r} and {other.path!r} have overlapping ownership"
+                    )
+            entries_seen.append(e)
             key = e.redis_key_prefix if e.is_directory else e.redis_key
             if key is None:
                 continue  # missing key already reported by Entry.validate()
@@ -191,6 +202,11 @@ class Classifier:
                 if _keys_collide(key, e.is_directory, other_key, other_is_prefix):
                     errors.append(
                         f"redis key/prefix {key!r} ({e.path}) collides with {other_key!r}"
+                    )
+                elif _metadata_keys_collide(key, e.is_directory, other_key, other_is_prefix):
+                    errors.append(
+                        f"redis key/prefix {key!r} ({e.path}) collides with a metadata key "
+                        f"generated for {other_key!r}"
                     )
             seen.append((key, e.is_directory))
         if errors:
@@ -250,3 +266,35 @@ def _keys_collide(key_a: str, a_is_prefix: bool, key_b: str, b_is_prefix: bool) 
         or (a_is_prefix and key_b.startswith(key_a))
         or (b_is_prefix and key_a.startswith(key_b))
     )
+
+
+def _metadata_keys_collide(key_a: str, a_is_prefix: bool, key_b: str, b_is_prefix: bool) -> bool:
+    """Whether either entry can overwrite the other's generated ``:meta`` key."""
+    if not a_is_prefix and not b_is_prefix:
+        return key_a == key_b + ":meta" or key_b == key_a + ":meta"
+    if a_is_prefix != b_is_prefix:
+        prefix = key_a if a_is_prefix else key_b
+        exact_key = key_b if a_is_prefix else key_a
+        return (exact_key + ":meta").startswith(prefix)
+    return False
+
+
+def _filesystem_path_overlap(a: Entry, b: Entry) -> bool:
+    """Whether two handlers can mirror the same filesystem object."""
+    a_path = os.path.realpath(a.path)
+    b_path = os.path.realpath(b.path)
+
+    def contains(directory: str, candidate: str) -> bool:
+        try:
+            return os.path.commonpath([directory, candidate]) == directory
+        except ValueError:
+            return False
+
+    def owns(entry: Entry, directory: str, other: Entry, candidate: str) -> bool:
+        if not entry.is_directory:
+            return False
+        if entry.recursive:
+            return contains(directory, candidate)
+        return not other.is_directory and os.path.dirname(candidate) == directory
+
+    return owns(a, a_path, b, b_path) or owns(b, b_path, a, a_path)

--- a/ufm-state-mirror/state_mirror/classifier.py
+++ b/ufm-state-mirror/state_mirror/classifier.py
@@ -31,6 +31,8 @@ from typing import Any, Optional
 
 import yaml
 
+from state_mirror.wire import META_SUFFIX
+
 log = logging.getLogger(__name__)
 
 
@@ -269,13 +271,13 @@ def _keys_collide(key_a: str, a_is_prefix: bool, key_b: str, b_is_prefix: bool) 
 
 
 def _metadata_keys_collide(key_a: str, a_is_prefix: bool, key_b: str, b_is_prefix: bool) -> bool:
-    """Whether either entry can overwrite the other's generated ``:meta`` key."""
+    """Whether either entry can overwrite the other's generated metadata key."""
     if not a_is_prefix and not b_is_prefix:
-        return key_a == key_b + ":meta" or key_b == key_a + ":meta"
+        return key_a == key_b + META_SUFFIX or key_b == key_a + META_SUFFIX
     if a_is_prefix != b_is_prefix:
         prefix = key_a if a_is_prefix else key_b
         exact_key = key_b if a_is_prefix else key_a
-        return (exact_key + ":meta").startswith(prefix)
+        return (exact_key + META_SUFFIX).startswith(prefix)
     return False
 
 
@@ -283,6 +285,8 @@ def _filesystem_path_overlap(a: Entry, b: Entry) -> bool:
     """Whether two handlers can mirror the same filesystem object."""
     a_path = os.path.realpath(a.path)
     b_path = os.path.realpath(b.path)
+    if a_path == b_path:
+        return False
 
     def contains(directory: str, candidate: str) -> bool:
         try:

--- a/ufm-state-mirror/state_mirror/handlers/directory.py
+++ b/ufm-state-mirror/state_mirror/handlers/directory.py
@@ -30,6 +30,8 @@ from state_mirror.handlers.base import BaseHandler, MirrorResult
 
 log = logging.getLogger(__name__)
 
+DEFAULT_RESTORED_FILE_MODE = 0o644
+
 
 class DirectoryHandler(BaseHandler):
     def _key_for_rel(self, relpath: str) -> str:
@@ -47,9 +49,8 @@ class DirectoryHandler(BaseHandler):
             for dirpath, _dirs, files in os.walk(root, onerror=self._raise_walk_error):
                 for name in sorted(files):
                     full = os.path.join(dirpath, name)
-                    # Do not pre-stat here: _read_file_nofollow performs the
-                    # authoritative open/fstat and returns any inspection error
-                    # through MirrorResult instead of silently skipping a child.
+                    if os.path.islink(full):
+                        continue
                     yield os.path.relpath(full, root), full
         else:
             with os.scandir(root) as it:
@@ -128,13 +129,19 @@ class DirectoryHandler(BaseHandler):
             except FileNotFoundError:
                 pass
             flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
-            # Match normal open(..., "wb") creation semantics for a new child:
-            # 0666 filtered by the process umask, rather than root-only 0600.
+            # New children must stay readable regardless of the restore process umask.
             fd = os.open(tmp, flags, 0o666, dir_fd=parent_fd)
-            with os.fdopen(fd, "wb") as fh:
-                fh.write(body)
-                fh.flush()
-                os.fsync(fh.fileno())
+            try:
+                if prev is None:
+                    os.fchmod(fd, DEFAULT_RESTORED_FILE_MODE)
+                with os.fdopen(fd, "wb") as fh:
+                    fd = -1
+                    fh.write(body)
+                    fh.flush()
+                    os.fsync(fh.fileno())
+            finally:
+                if fd >= 0:
+                    os.close(fd)
             os.replace(tmp, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
             if prev is not None:
                 dest_fd = os.open(

--- a/ufm-state-mirror/state_mirror/handlers/directory.py
+++ b/ufm-state-mirror/state_mirror/handlers/directory.py
@@ -31,6 +31,7 @@ from state_mirror.handlers.base import BaseHandler, MirrorResult
 log = logging.getLogger(__name__)
 
 DEFAULT_RESTORED_FILE_MODE = 0o644
+DEFAULT_RESTORED_DIR_MODE = 0o755
 
 
 class DirectoryHandler(BaseHandler):
@@ -102,10 +103,20 @@ class DirectoryHandler(BaseHandler):
         parent_fd = os.open(self.entry.path, flags)
         try:
             for part in parts[:-1]:
+                created = False
                 if create:
-                    with suppress(FileExistsError):
-                        os.mkdir(part, dir_fd=parent_fd)
+                    try:
+                        os.mkdir(part, DEFAULT_RESTORED_DIR_MODE, dir_fd=parent_fd)
+                        created = True
+                    except FileExistsError:
+                        created = False
                 next_fd = os.open(part, flags, dir_fd=parent_fd)
+                try:
+                    if created:
+                        os.fchmod(next_fd, DEFAULT_RESTORED_DIR_MODE)
+                except Exception:
+                    os.close(next_fd)
+                    raise
                 os.close(parent_fd)
                 parent_fd = next_fd
             return parent_fd, parts[-1]

--- a/ufm-state-mirror/state_mirror/handlers/directory.py
+++ b/ufm-state-mirror/state_mirror/handlers/directory.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 import os
 import stat
+from contextlib import suppress
 
 from state_mirror import wire
 from state_mirror.handlers.base import BaseHandler, MirrorResult
@@ -51,11 +52,9 @@ class DirectoryHandler(BaseHandler):
                     # through MirrorResult instead of silently skipping a child.
                     yield os.path.relpath(full, root), full
         else:
-            # Preserve the existing traversal behavior in the outcome-accounting
-            # change; symlink hardening is delivered by the next stacked PR.
             with os.scandir(root) as it:
                 for de in sorted(it, key=lambda e: e.name):
-                    if de.is_file(follow_symlinks=True):
+                    if de.is_file(follow_symlinks=False):
                         yield de.name, de.path
 
     @staticmethod
@@ -71,24 +70,95 @@ class DirectoryHandler(BaseHandler):
             yield key[len(prefix) :]
 
     def restore(self) -> bool:
+        """Restore children only after every backend path passes containment.
+
+        Validation is deliberately a separate first pass. If one malicious or
+        corrupt key escapes the configured root, no earlier safe child should
+        already have been written before the entry fails closed.
+        """
         count = 0
-        root = os.path.realpath(self.entry.path)
-        for relpath in self._iter_redis_relpaths():
-            dest = os.path.join(self.entry.path, relpath)
-            # Restore is the fail-closed boundary: a corrupt/hostile backend key
-            # containing ``..`` must not let us write outside the entry root.
-            if not self._within(root, dest):
-                log.error("restore: skipping child key with out-of-root path %r", relpath)
-                continue
-            if self._restore_one(self.store, self._key_for_rel(relpath), dest) is not None:
+        children = list(self._iter_redis_relpaths())
+        for relpath in children:
+            self._validate_relpath(relpath)
+        os.makedirs(self.entry.path, exist_ok=True)
+        for relpath in children:
+            if self._restore_child_secure(relpath):
                 count += 1
         log.info("restore: %s restored %d child file(s)", self.entry.path, count)
         return count > 0
 
     @staticmethod
-    def _within(root: str, dest: str) -> bool:
-        real = os.path.realpath(dest)
-        return real == root or real.startswith(root + os.sep)
+    def _validate_relpath(relpath: str) -> list[str]:
+        parts = relpath.split(os.sep)
+        if not relpath or os.path.isabs(relpath) or any(part in ("", ".", "..") for part in parts):
+            raise wire.WireError(f"directory child has out-of-root path {relpath!r}")
+        return parts
+
+    def _open_parent(self, relpath: str, *, create: bool) -> tuple[int, str]:
+        """Open a child's parent via no-follow directory descriptors."""
+        parts = self._validate_relpath(relpath)
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        parent_fd = os.open(self.entry.path, flags)
+        try:
+            for part in parts[:-1]:
+                if create:
+                    with suppress(FileExistsError):
+                        os.mkdir(part, dir_fd=parent_fd)
+                next_fd = os.open(part, flags, dir_fd=parent_fd)
+                os.close(parent_fd)
+                parent_fd = next_fd
+            return parent_fd, parts[-1]
+        except Exception:
+            os.close(parent_fd)
+            raise
+
+    def _restore_child_secure(self, relpath: str) -> bool:
+        result = self.store.get(self._key_for_rel(relpath))
+        if result is None:
+            return False
+        body, _meta = result
+        parent_fd, name = self._open_parent(relpath, create=True)
+        tmp = name + ".statemirror.tmp"
+        prev = None
+        try:
+            try:
+                prev = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+                if not stat.S_ISREG(prev.st_mode):
+                    raise OSError(f"refusing to replace non-regular file: {relpath}")
+            except FileNotFoundError:
+                pass
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+            # Match normal open(..., "wb") creation semantics for a new child:
+            # 0666 filtered by the process umask, rather than root-only 0600.
+            fd = os.open(tmp, flags, 0o666, dir_fd=parent_fd)
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(body)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            if prev is not None:
+                dest_fd = os.open(
+                    name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=parent_fd
+                )
+                try:
+                    try:
+                        os.fchmod(dest_fd, stat.S_IMODE(prev.st_mode))
+                    except OSError as exc:
+                        log.debug("fchmod of restored child %s failed: %s", relpath, exc)
+                    if hasattr(os, "geteuid") and os.geteuid() == 0:
+                        try:
+                            os.fchown(dest_fd, prev.st_uid, prev.st_gid)
+                        except OSError as exc:
+                            log.warning("fchown of restored child %s failed: %s", relpath, exc)
+                finally:
+                    os.close(dest_fd)
+            return True
+        except Exception:
+            with suppress(FileNotFoundError):
+                os.unlink(tmp, dir_fd=parent_fd)
+            raise
+        finally:
+            os.close(parent_fd)
 
     def mirror(self) -> MirrorResult:
         writes = 0
@@ -97,7 +167,7 @@ class DirectoryHandler(BaseHandler):
         try:
             for relpath, full in self._iter_local_files():
                 try:
-                    body = self._read_file(full)
+                    body = self._read_file_nofollow(relpath)
                     key = self._key_for_rel(relpath)
                     if self._push_if_changed(key, body):
                         log.info("mirror: shipped %s -> %s", full, key)
@@ -111,6 +181,24 @@ class DirectoryHandler(BaseHandler):
             log.exception("mirror: directory traversal failed for %s", self.entry.path)
             failures.append(exc)
         return MirrorResult(writes=writes, reads=reads, failures=tuple(failures))
+
+    def _read_file_nofollow(self, relpath: str) -> bytes:
+        """Read one regular child without following any path component."""
+        parent_fd, name = self._open_parent(relpath, create=False)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        fd = -1
+        try:
+            fd = os.open(name, flags, dir_fd=parent_fd)
+            mode = os.fstat(fd).st_mode
+            if not stat.S_ISREG(mode):
+                raise OSError(f"refusing to mirror non-regular file: {relpath}")
+            with os.fdopen(fd, "rb") as fh:
+                fd = -1
+                return fh.read()
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            os.close(parent_fd)
 
     def on_delete_child(self, relpath: str) -> None:
         log.info("on_delete_child: dropping %s", relpath)

--- a/ufm-state-mirror/tests/test_classifier.py
+++ b/ufm-state-mirror/tests/test_classifier.py
@@ -293,6 +293,30 @@ class TestClassifierDocument:
                 }
             )
 
+    def test_duplicate_directory_path_does_not_also_report_overlap(self):
+        with pytest.raises(ClassifierError) as excinfo:
+            Classifier.from_dict(
+                {
+                    "entries": [
+                        {
+                            "path": "/opt/ufm/files/conf/plugins",
+                            "handler": "directory",
+                            "redis_key_prefix": "ufm:cfg:plugins-a:",
+                            "recursive": True,
+                        },
+                        {
+                            "path": "/opt/ufm/files/conf/plugins",
+                            "handler": "directory",
+                            "redis_key_prefix": "ufm:cfg:plugins-b:",
+                            "recursive": True,
+                        },
+                    ]
+                }
+            )
+        msg = str(excinfo.value)
+        assert "duplicate path" in msg
+        assert "overlapping ownership" not in msg
+
     def test_multiple_errors_aggregated(self):
         # Two identical entries trip both the duplicate-path and the key-collision
         # checks; the error reports both rather than failing on the first.

--- a/ufm-state-mirror/tests/test_classifier.py
+++ b/ufm-state-mirror/tests/test_classifier.py
@@ -204,6 +204,95 @@ class TestClassifierDocument:
         )
         assert len(c) == 2
 
+    def test_body_key_cannot_collide_with_another_metadata_key(self):
+        with pytest.raises(ClassifierError, match="metadata key"):
+            Classifier.from_dict(
+                {
+                    "entries": [
+                        _blob(redis_key="ufm:state:a"),
+                        _blob(
+                            path="/opt/ufm/files/conf/b.json",
+                            redis_key="ufm:state:a:meta",
+                        ),
+                    ]
+                }
+            )
+
+    def test_directory_prefix_cannot_contain_another_metadata_key(self):
+        with pytest.raises(ClassifierError, match="metadata key"):
+            Classifier.from_dict(
+                {
+                    "entries": [
+                        _blob(redis_key="ufm:state:a"),
+                        {
+                            "path": "/opt/ufm/files/conf/plugins",
+                            "handler": "directory",
+                            "redis_key_prefix": "ufm:state:a:m",
+                        },
+                    ]
+                }
+            )
+
+    def test_file_under_recursive_directory_rejected(self):
+        with pytest.raises(ClassifierError, match="overlapping ownership"):
+            Classifier.from_dict(
+                {
+                    "entries": [
+                        {
+                            "path": "/opt/ufm/files/conf/plugins",
+                            "handler": "directory",
+                            "redis_key_prefix": "ufm:cfg:plugins:",
+                            "recursive": True,
+                        },
+                        _blob(
+                            path="/opt/ufm/files/conf/plugins/child.json",
+                            redis_key="ufm:state:child",
+                        ),
+                    ]
+                }
+            )
+
+    def test_symlink_alias_under_recursive_directory_rejected(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        alias = tmp_path / "alias"
+        alias.symlink_to(real, target_is_directory=True)
+        with pytest.raises(ClassifierError, match="overlapping ownership"):
+            Classifier.from_dict(
+                {
+                    "entries": [
+                        {
+                            "path": str(alias),
+                            "handler": "directory",
+                            "redis_key_prefix": "ufm:cfg:alias:",
+                            "recursive": True,
+                        },
+                        _blob(
+                            path=str(real / "child.json"),
+                            redis_key="ufm:state:child",
+                        ),
+                    ]
+                }
+            )
+
+    def test_file_directly_under_nonrecursive_directory_rejected(self):
+        with pytest.raises(ClassifierError, match="overlapping ownership"):
+            Classifier.from_dict(
+                {
+                    "entries": [
+                        {
+                            "path": "/opt/ufm/files/conf/plugins",
+                            "handler": "directory",
+                            "redis_key_prefix": "ufm:cfg:plugins:",
+                        },
+                        _blob(
+                            path="/opt/ufm/files/conf/plugins/child.json",
+                            redis_key="ufm:state:child",
+                        ),
+                    ]
+                }
+            )
+
     def test_multiple_errors_aggregated(self):
         # Two identical entries trip both the duplicate-path and the key-collision
         # checks; the error reports both rather than failing on the first.

--- a/ufm-state-mirror/tests/test_handlers.py
+++ b/ufm-state-mirror/tests/test_handlers.py
@@ -232,6 +232,25 @@ class TestDirectoryHandler:
         assert not result.failures
         assert fake_redis.get("ufm:cfg:linked.conf") is None
 
+    def test_recursive_directory_skips_symlink_child(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        secret = tmp_path / "secret"
+        secret.write_bytes(b"do-not-copy")
+        (root / "linked.conf").symlink_to(secret)
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:",
+                "recursive": True,
+            }
+        )
+        result = _handler(entry, fake_redis).mirror()
+        assert result.outcome is MirrorOutcome.LOCAL_NOOP
+        assert not result.failures
+        assert fake_redis.get("ufm:cfg:linked.conf") is None
+
     def test_directory_refuses_symlink_parent_component(self, fake_redis, tmp_path):
         root = tmp_path / "plugins"
         outside = tmp_path / "outside"
@@ -365,7 +384,9 @@ class TestDirectoryHandler:
             _handler(entry, fake_redis).restore()
         assert not (outside / "file.conf").exists()
 
-    def test_directory_restore_new_child_is_readable(self, fake_redis, tmp_path):
+    def test_directory_restore_new_child_uses_deterministic_readable_mode(
+        self, fake_redis, tmp_path
+    ):
         root = tmp_path / "plugins"
         key = "ufm:cfg:plugins:new.conf"
         body = b"config"
@@ -382,9 +403,13 @@ class TestDirectoryHandler:
                 "redis_key_prefix": "ufm:cfg:plugins:",
             }
         )
-        assert _handler(entry, fake_redis).restore() is True
+        old_umask = os.umask(0o077)
+        try:
+            assert _handler(entry, fake_redis).restore() is True
+        finally:
+            os.umask(old_umask)
         mode = stat.S_IMODE((root / "new.conf").stat().st_mode)
-        assert mode & 0o044
+        assert mode == directory.DEFAULT_RESTORED_FILE_MODE
 
     def test_directory_restore_chown_failure_is_nonfatal(self, fake_redis, tmp_path, monkeypatch):
         root = tmp_path / "plugins"

--- a/ufm-state-mirror/tests/test_handlers.py
+++ b/ufm-state-mirror/tests/test_handlers.py
@@ -411,6 +411,46 @@ class TestDirectoryHandler:
         mode = stat.S_IMODE((root / "new.conf").stat().st_mode)
         assert mode == directory.DEFAULT_RESTORED_FILE_MODE
 
+    def test_directory_restore_new_subdirs_use_deterministic_traversable_mode(
+        self, fake_redis, tmp_path
+    ):
+        root = tmp_path / "plugins"
+        preserved = root / "preserved"
+        preserved.mkdir(parents=True)
+        preserved.chmod(0o700)
+        key = "ufm:cfg:plugins:preserved/tools/nvp/new.conf"
+        body = b"config"
+        wire.write_pair(
+            fake_redis,
+            key,
+            body,
+            wire.build_meta(body, "directory", UFM_VERSION, WRITTEN_BY),
+        )
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+                "recursive": True,
+            }
+        )
+        old_umask = os.umask(0o077)
+        try:
+            assert _handler(entry, fake_redis).restore() is True
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(preserved.stat().st_mode) == 0o700
+        assert stat.S_IMODE((preserved / "tools").stat().st_mode) == (
+            directory.DEFAULT_RESTORED_DIR_MODE
+        )
+        assert stat.S_IMODE((preserved / "tools" / "nvp").stat().st_mode) == (
+            directory.DEFAULT_RESTORED_DIR_MODE
+        )
+        assert stat.S_IMODE((preserved / "tools" / "nvp" / "new.conf").stat().st_mode) == (
+            directory.DEFAULT_RESTORED_FILE_MODE
+        )
+
     def test_directory_restore_chown_failure_is_nonfatal(self, fake_redis, tmp_path, monkeypatch):
         root = tmp_path / "plugins"
         root.mkdir()

--- a/ufm-state-mirror/tests/test_handlers.py
+++ b/ufm-state-mirror/tests/test_handlers.py
@@ -14,12 +14,13 @@
 
 import os
 import sqlite3
+import stat
 
 import pytest
 
 from state_mirror import wire
 from state_mirror.classifier import Entry
-from state_mirror.handlers import base, make_handler
+from state_mirror.handlers import base, directory, make_handler
 from state_mirror.handlers.base import BaseHandler, MirrorOutcome
 from state_mirror.handlers.blob import BlobHandler
 from state_mirror.handlers.directory import DirectoryHandler
@@ -203,19 +204,53 @@ class TestDirectoryHandler:
             {"path": str(root), "handler": "directory", "redis_key_prefix": "ufm:cfg:plugins:"}
         )
         handler = _handler(entry, fake_redis)
-        real_read = handler._read_file
+        real_read = handler._read_file_nofollow
 
         def selective(path):
             if path.endswith("a.conf"):
                 raise OSError("unreadable")
             return real_read(path)
 
-        monkeypatch.setattr(handler, "_read_file", selective)
+        monkeypatch.setattr(handler, "_read_file_nofollow", selective)
         result = handler.mirror()
         assert result.outcome is MirrorOutcome.WROTE
         assert len(result.failures) == 1  # b.conf still shipped despite a.conf failing
         assert fake_redis.get("ufm:cfg:plugins:a.conf") is None
         assert fake_redis.get("ufm:cfg:plugins:b.conf") == b"BBB"
+
+    def test_directory_refuses_symlink_child(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        secret = tmp_path / "secret"
+        secret.write_bytes(b"do-not-copy")
+        (root / "linked.conf").symlink_to(secret)
+        entry = Entry.from_dict(
+            {"path": str(root), "handler": "directory", "redis_key_prefix": "ufm:cfg:"}
+        )
+        result = _handler(entry, fake_redis).mirror()
+        assert result.outcome is MirrorOutcome.LOCAL_NOOP
+        assert not result.failures
+        assert fake_redis.get("ufm:cfg:linked.conf") is None
+
+    def test_directory_refuses_symlink_parent_component(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        outside = tmp_path / "outside"
+        root.mkdir()
+        outside.mkdir()
+        (outside / "secret.conf").write_bytes(b"secret")
+        (root / "sub").symlink_to(outside, target_is_directory=True)
+
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:",
+                "recursive": True,
+            }
+        )
+        handler = _handler(entry, fake_redis)
+        with pytest.raises(OSError, match="Not a directory|Too many levels"):
+            handler._read_file_nofollow("sub/secret.conf")
 
     def test_recursive_walk_error_fails_reconcile(self, fake_redis, tmp_path, monkeypatch):
         root = tmp_path / "plugins"
@@ -273,6 +308,111 @@ class TestDirectoryHandler:
         assert result.failures[0] is backend_failure
         assert isinstance(result.failures[1], PermissionError)
         assert result.backend_failures == (backend_failure,)
+
+    def test_directory_restore_fails_closed_on_out_of_root_key(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        safe_key = "ufm:cfg:plugins:safe.conf"
+        key = "ufm:cfg:plugins:../escaped"
+        body = b"unsafe"
+        wire.write_pair(
+            fake_redis,
+            safe_key,
+            b"safe",
+            wire.build_meta(b"safe", "directory", UFM_VERSION, WRITTEN_BY),
+        )
+        wire.write_pair(
+            fake_redis,
+            key,
+            body,
+            wire.build_meta(body, "directory", UFM_VERSION, WRITTEN_BY),
+        )
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+                "recursive": True,
+            }
+        )
+        with pytest.raises(wire.WireError, match="out-of-root"):
+            _handler(entry, fake_redis).restore()
+        assert not (root / "safe.conf").exists()
+        assert not (tmp_path / "escaped").exists()
+
+    def test_directory_restore_refuses_symlink_parent(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        outside = tmp_path / "outside"
+        root.mkdir()
+        outside.mkdir()
+        (root / "sub").symlink_to(outside, target_is_directory=True)
+        key = "ufm:cfg:plugins:sub/file.conf"
+        body = b"safe"
+        wire.write_pair(
+            fake_redis,
+            key,
+            body,
+            wire.build_meta(body, "directory", UFM_VERSION, WRITTEN_BY),
+        )
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+                "recursive": True,
+            }
+        )
+        with pytest.raises(OSError, match="Not a directory|Too many levels"):
+            _handler(entry, fake_redis).restore()
+        assert not (outside / "file.conf").exists()
+
+    def test_directory_restore_new_child_is_readable(self, fake_redis, tmp_path):
+        root = tmp_path / "plugins"
+        key = "ufm:cfg:plugins:new.conf"
+        body = b"config"
+        wire.write_pair(
+            fake_redis,
+            key,
+            body,
+            wire.build_meta(body, "directory", UFM_VERSION, WRITTEN_BY),
+        )
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+            }
+        )
+        assert _handler(entry, fake_redis).restore() is True
+        mode = stat.S_IMODE((root / "new.conf").stat().st_mode)
+        assert mode & 0o044
+
+    def test_directory_restore_chown_failure_is_nonfatal(self, fake_redis, tmp_path, monkeypatch):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "existing.conf").write_bytes(b"old")
+        key = "ufm:cfg:plugins:existing.conf"
+        body = b"new"
+        wire.write_pair(
+            fake_redis,
+            key,
+            body,
+            wire.build_meta(body, "directory", UFM_VERSION, WRITTEN_BY),
+        )
+        entry = Entry.from_dict(
+            {
+                "path": str(root),
+                "handler": "directory",
+                "redis_key_prefix": "ufm:cfg:plugins:",
+            }
+        )
+        monkeypatch.setattr(directory.os, "geteuid", lambda: 0)
+
+        def deny_chown(*_args):
+            raise PermissionError
+
+        monkeypatch.setattr(directory.os, "fchown", deny_chown)
+        assert _handler(entry, fake_redis).restore() is True
+        assert (root / "existing.conf").read_bytes() == body
 
 
 class TestSqliteHandler:


### PR DESCRIPTION
## What

Harden directory mirroring/restoration and classifier ownership validation.

- Reject generated `:meta` key collisions.
- Reject recursive and non-recursive filesystem ownership overlaps.
- Resolve classifier path aliases before overlap checks.
- Refuse symlinks in every directory path component.
- Use descriptor-relative traversal and atomic restore writes.
- Preserve prior identity best-effort and retain readable defaults for new children.
- Validate every backend child path before writing any entry.

## Why ?

Redmine [#5134987](https://redmine.mellanox.com/issues/5134987), under story [#5079041](https://redmine.mellanox.com/issues/5079041).

Lexical containment and final-component no-follow checks leave intermediate-directory race windows, while overlapping classifier ownership can mirror or restore the same file through multiple handlers.

## How ?

All directory reads and writes traverse from an opened root directory descriptor with no-follow checks for every component. Restore creates and replaces children relative to retained directory descriptors. Classifier validation compares resolved filesystem ownership and physical backend keyspaces.

This is **2/3** in a stacked series:

1. [PR #381](https://github.com/Mellanox/ufm_sdk_3.0/pull/381) — required base.
2. This PR — directory and classifier path safety.
3. [PR #383](https://github.com/Mellanox/ufm_sdk_3.0/pull/383) — SQLite replacement detection and logging parity.

## Testing ?

- Python 3.12: `ruff check .` — passed.
- Python 3.12: `ruff format --check .` — passed.
- Python 3.12: `python -m pytest -q` — **228 passed**.
- `git diff --check` — passed.
- NVIDIA copyright validation — passed for the four-file delta.
- Fresh-context review — no actionable correctness regressions.
- GitHub Actions Docker build — passed.
