### PR TITLE
issue:5134987 [BugFix] [3/3] Detect SQLite replacement and align logging

### DIFF
--- a/ufm-state-mirror/README.md
+++ b/ufm-state-mirror/README.md
@@ -118,7 +118,7 @@ The Helm chart ships an optional `ServiceMonitor` + `PrometheusRule`
 | `STATE_MIRROR_ALLOW_POLL_ONLY` | `false` | Internal unsupported escape hatch: permit readiness without watchdog after a clean reconcile; emits warnings and metrics. |
 | `STATE_MIRROR_BACKEND` | `configmap` | Install-wide storage backend: `configmap` (default, etcd-backed) or `redis` (BYO). Invalid values fail closed at startup. |
 | `STATE_MIRROR_LOG_LEVEL` | `INFO` | Log level. |
-| `STATE_MIRROR_LOG_TO_FILE` | `true` | Also log to `/opt/ufm/files/log/state_mirror.log`. |
+| `STATE_MIRROR_LOG_TO_FILE` | `false` | Also log to `/opt/ufm/files/log/state_mirror.log` when explicitly enabled. |
 | `STATE_MIRROR_LOG_DIR` | `/opt/ufm/files/log` | File log directory. |
 | `REDIS_SENTINEL_HOSTS` | _(empty)_ | `host:port,...`; enables Sentinel discovery. |
 | `REDIS_MASTER_NAME` | `ufm` | Sentinel master name. |

--- a/ufm-state-mirror/state_mirror/handlers/sqlite.py
+++ b/ufm-state-mirror/state_mirror/handlers/sqlite.py
@@ -26,8 +26,8 @@ a DB's journal mode -- it only reads.
 Change detection: a counter-only poll would miss live writes on a WAL-mode DB,
 because in WAL mode a write lands in ``-wal`` and does NOT bump the main DB
 header's change counter until a checkpoint. ``signature()`` therefore combines
-the header change counter with the ``-wal`` file's size and mtime, so it is
-correct whether the DB is in rollback-journal or WAL mode.
+main DB identity, size, timestamps, header change counter, and the ``-wal``
+file's size and mtime, so it detects both replacement and ordinary WAL writes.
 """
 
 from __future__ import annotations
@@ -78,14 +78,32 @@ class SqliteHandler(BaseHandler):
             return 0
         return int.from_bytes(header[_CHANGE_COUNTER_OFFSET:_HEADER_MIN_SIZE], "big")
 
-    def signature(self) -> tuple[int, int, int]:
-        """A cheap change fingerprint: (header change counter, wal size, wal mtime)."""
+    def signature(self) -> tuple[int, int, int, int, int, int, int, int]:
+        """Fingerprint main DB and WAL metadata plus the header counter.
+
+        Main-file identity, size and timestamps detect same-counter replacement;
+        WAL size/mtime detects writes that have not advanced the main header.
+        """
         cc = self.read_change_counter(self.entry.path)
+        main = os.stat(self.entry.path)
         try:
             wal = os.stat(self._wal_path(self.entry.path))
-            return (cc, wal.st_size, wal.st_mtime_ns)
         except FileNotFoundError:
-            return (cc, -1, -1)
+            wal_size = -1
+            wal_mtime_ns = -1
+        else:
+            wal_size = wal.st_size
+            wal_mtime_ns = wal.st_mtime_ns
+        return (
+            cc,
+            main.st_dev,
+            main.st_ino,
+            main.st_size,
+            main.st_mtime_ns,
+            main.st_ctime_ns,
+            wal_size,
+            wal_mtime_ns,
+        )
 
     @staticmethod
     def integrity_check(path: str) -> None:

--- a/ufm-state-mirror/state_mirror/logconfig.py
+++ b/ufm-state-mirror/state_mirror/logconfig.py
@@ -76,7 +76,7 @@ def _resolve_level() -> int:
 def _maybe_add_file_handler(
     root_logger: logging.Logger, formatter: logging.Formatter, log: logging.Logger
 ) -> None:
-    if os.environ.get("STATE_MIRROR_LOG_TO_FILE", "true").lower() != "true":
+    if os.environ.get("STATE_MIRROR_LOG_TO_FILE", "false").lower() != "true":
         return
     log_dir = os.environ.get("STATE_MIRROR_LOG_DIR", DEFAULT_LOG_DIR)
     path = os.path.join(log_dir, LOG_FILE_NAME)

--- a/ufm-state-mirror/tests/test_logconfig.py
+++ b/ufm-state-mirror/tests/test_logconfig.py
@@ -57,6 +57,11 @@ class TestResolveLevel:
 
 
 class TestSetupLogging:
+    def test_stdout_only_by_default(self, monkeypatch):
+        monkeypatch.delenv("STATE_MIRROR_LOG_TO_FILE", raising=False)
+        logconfig.setup_logging("state_mirror.test")
+        assert _file_handlers() == []
+
     def test_stdout_only_when_file_disabled(self, monkeypatch):
         monkeypatch.setenv("STATE_MIRROR_LOG_TO_FILE", "false")
         logconfig.setup_logging("state_mirror.test")

--- a/ufm-state-mirror/tests/test_sqlite.py
+++ b/ufm-state-mirror/tests/test_sqlite.py
@@ -144,6 +144,39 @@ class TestSnapshot:
         assert rh.restore() is True
         assert _row_count(str(dest)) == 2
 
+    def test_signature_detects_same_counter_main_file_replacement(self, fake_redis, tmp_path):
+        db = tmp_path / "gv.db"
+        _make_db(str(db), ["a"])
+        h = _handler(db, fake_redis)
+        original = h.signature()
+        stat = db.stat()
+        replacement = tmp_path / "replacement.db"
+        _make_db(str(replacement), ["different" * 100 for _ in range(1000)])
+        # Force the header counter and mtime back to the original values; size
+        # remains part of the signature and must still detect replacement.
+        data = bytearray(replacement.read_bytes())
+        data[24:28] = db.read_bytes()[24:28]
+        db.write_bytes(data)
+        db.touch()
+        os.utime(db, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+        assert h.signature() != original
+
+    def test_signature_detects_same_size_mtime_counter_replacement(self, fake_redis, tmp_path):
+        db = tmp_path / "gv.db"
+        replacement = tmp_path / "replacement.db"
+        _make_db(str(db), ["a"])
+        _make_db(str(replacement), ["b"])
+        h = _handler(db, fake_redis)
+        original = h.signature()
+        original_stat = db.stat()
+        data = bytearray(replacement.read_bytes())
+        data[24:28] = db.read_bytes()[24:28]
+        replacement.write_bytes(data)
+        assert replacement.stat().st_size == original_stat.st_size
+        os.replace(replacement, db)
+        os.utime(db, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+        assert h.signature() != original
+
 
 class TestRestoreFailClosed:
     def test_restore_raises_on_corrupt_base(self, fake_redis, tmp_path):


### PR DESCRIPTION
## What

Detect SQLite database replacement reliably and align the engine logging default with deployed stdout-only behavior.

- Include main DB device, inode, size, mtime, and ctime in the SQLite fingerprint.
- Retain WAL size and mtime detection.
- Default `STATE_MIRROR_LOG_TO_FILE` to `false`.
- Document and test both behaviors.

## Why ?

Redmine [#5134987](https://redmine.mellanox.com/issues/5134987), under story [#5079041](https://redmine.mellanox.com/issues/5079041).

A same-counter and no-WAL database replacement could otherwise remain undetected, and the engine default differed from the chart's stdout-only configuration.

## How ?

The cheap pre-snapshot signature now includes replacement-sensitive file identity and timestamps. File logging remains available only when explicitly enabled.

This is **3/3** in a stacked series:

1. [PR #381](https://github.com/Mellanox/ufm_sdk_3.0/pull/381) — startup correctness and health accounting.
2. [PR #382](https://github.com/Mellanox/ufm_sdk_3.0/pull/382) — required base.
3. This PR — SQLite replacement detection and logging parity.

## Testing ?

- Python 3.12: `ruff check .` — passed.
- Python 3.12: `ruff format --check .` — passed.
- Python 3.12: `python -m pytest -q` — **231 passed**.
- `git diff --check` — passed.
- NVIDIA copyright validation — passed for the four changed Python files.
- Fresh-context review — no actionable correctness regressions.
- GitHub Actions Docker build — passed.
