### PR TITLE
issue:5140121 [BugFix] add StateMirror ConfigMap oversize alert contract

### DIFF
--- a/ufm-state-mirror/README.md
+++ b/ufm-state-mirror/README.md
@@ -107,6 +107,21 @@ The same image runs in two roles inside the UFM pod:
 The Helm chart ships an optional `ServiceMonitor` + `PrometheusRule`
 (`stateMirror.metrics.*`) that alert on these.
 
+### PrometheusRule Contract
+
+StateMirror owns the alert contract in
+[`deploy/state-mirror-prometheusrule.yaml`](deploy/state-mirror-prometheusrule.yaml).
+Consumer charts should package or template that rule with their own
+namespace/labels. The contract includes `StateMirrorConfigMapTooLarge`, which
+alerts on:
+
+```promql
+increase(state_mirror_backend_errors_total{reason="toolarge"}[5m]) > 0
+```
+
+This alert covers ConfigMap backend object-size failures where StateMirror is
+still running, but newer snapshots are not durable.
+
 ## Configuration (environment)
 
 | Variable | Default | Meaning |

--- a/ufm-state-mirror/deploy/state-mirror-prometheusrule.yaml
+++ b/ufm-state-mirror/deploy/state-mirror-prometheusrule.yaml
@@ -1,0 +1,30 @@
+# StateMirror alert contract for consumers that deploy the Prometheus Operator.
+# Consumer charts should template metadata.namespace/labels as needed, but keep
+# the rule expression and remediation text aligned with this source artifact.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: state-mirror
+  labels:
+    app.kubernetes.io/name: ufm-state-mirror
+    app.kubernetes.io/component: state-mirror
+spec:
+  groups:
+    - name: ufm-state-mirror
+      rules:
+        - alert: StateMirrorConfigMapTooLarge
+          expr: |
+            increase(state_mirror_backend_errors_total{reason="toolarge"}[5m]) > 0
+          for: 5m
+          labels:
+            severity: critical
+            component: state-mirror
+          annotations:
+            summary: "StateMirror ConfigMap backend object is too large"
+            description: >-
+              StateMirror has failed to persist state because a ConfigMap
+              backend object exceeded the effective Kubernetes object size
+              limit for 5m. Newer snapshots for that object are not durable;
+              a pod restart can restore an older snapshot. Reduce the mirrored
+              state size or switch this deployment to the supported BYO
+              Redis/Valkey backend.

--- a/ufm-state-mirror/tests/test_alerts.py
+++ b/ufm-state-mirror/tests/test_alerts.py
@@ -1,0 +1,57 @@
+#
+# Copyright © 2009-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+"""Tests for the StateMirror Prometheus alert contract."""
+
+from pathlib import Path
+
+import yaml
+
+RULE_PATH = Path(__file__).resolve().parents[1] / "deploy" / "state-mirror-prometheusrule.yaml"
+
+
+def _rule_text() -> str:
+    return RULE_PATH.read_text(encoding="utf-8")
+
+
+def _rule_doc() -> dict:
+    return yaml.safe_load(_rule_text())
+
+
+def _alert(name: str) -> dict:
+    rules = _rule_doc()["spec"]["groups"][0]["rules"]
+    return next(rule for rule in rules if rule["alert"] == name)
+
+
+def test_prometheusrule_contract_is_valid_yaml():
+    doc = _rule_doc()
+    assert doc["apiVersion"] == "monitoring.coreos.com/v1"
+    assert doc["kind"] == "PrometheusRule"
+
+
+def test_configmap_toolarge_alert_is_shipped():
+    alert = _alert("StateMirrorConfigMapTooLarge")
+    assert (
+        alert["expr"].strip()
+        == 'increase(state_mirror_backend_errors_total{reason="toolarge"}[5m]) > 0'
+    )
+    assert alert["for"] == "5m"
+    assert alert["labels"]["severity"] == "critical"
+    assert alert["labels"]["component"] == "state-mirror"
+
+
+def test_configmap_toolarge_alert_documents_remediation():
+    description = _alert("StateMirrorConfigMapTooLarge")["annotations"]["description"]
+    assert "ConfigMap" in description
+    assert "not durable" in description
+    assert "BYO" in description
+    assert "Redis/Valkey" in description


### PR DESCRIPTION
## What
Add a StateMirror-owned PrometheusRule contract artifact for ConfigMap oversize persistence failures.

The new `StateMirrorConfigMapTooLarge` alert watches `state_mirror_backend_errors_total{reason="toolarge"}` and documents remediation for operators. The README now points consumers to the StateMirror-owned alert contract, and a unit test parses the rule YAML to protect the alert expression and remediation text.

## Why ?
Redmine #5140121 is a StateMirror observability gap: StateMirror reports ConfigMap object-size failures via `state_mirror_backend_errors_total{reason="toolarge"}`, but the alert contract did not live with the StateMirror component. Operators can miss that newer ConfigMap-backed snapshots are not durable.

## How ?
Add `ufm-state-mirror/deploy/state-mirror-prometheusrule.yaml` as the source alert contract. Consumer charts can package/template it with their own namespace and labels while keeping the expression and remediation aligned with StateMirror.

## Testing ?
- `/tmp/ufm-state-mirror-5140121-venv/bin/ruff check .` - passed
- `/tmp/ufm-state-mirror-5140121-venv/bin/ruff format --check .` - passed
- `/tmp/ufm-state-mirror-5140121-venv/bin/python -m pytest -q` - passed (`237 passed`)
- `git diff --check` - passed

## Special triggers
_Use the following phrases as comments to trigger different runs_

* ```bot:retest``` rerun Jenkins CI (to rerun GitHub CI, use "Checks" tab on PR page and rerun _all_ jobs)
* ```bot:upgrade``` run additional update tests
